### PR TITLE
feat(helm): Add Redis and ClickHouse deployment configurations

### DIFF
--- a/charts/she/README.md
+++ b/charts/she/README.md
@@ -103,6 +103,61 @@ Then install the chart with your custom values:
 helm install [RELEASE_NAME] ./charts/she -f values.yaml
 ```
 
+### Database Configuration
+
+#### ClickHouse Configuration
+```yaml
+enterprise:
+  config:
+    clickhouse:
+      allowAuditLogs: true
+      allowWorkspaceActivityLogs: true
+      # External ClickHouse configuration
+      external: false
+      host: "your-clickhouse-host"
+      user: "your-clickhouse-user"
+      password: "your-clickhouse-password"
+      
+      # Self-hosted ClickHouse configuration
+      clickhouse:
+        image: "clickhouse/clickhouse-server:latest"
+        username: "default"
+        password: "clickhouse-password"
+        persistence:
+          size: "10Gi"
+```
+
+#### Redis Configuration
+```yaml
+enterprise:
+  config:
+    horizontalScaling:
+      enabled: true
+    redis:
+      # External Redis configuration
+      external: false
+      host: "your-redis-host"
+      password: "your-redis-password"
+      
+      # Self-hosted Redis configuration
+      redis:
+        image: "redis:latest"
+        password: "redis-password"
+        persistence:
+          size: "5Gi"
+```
+
+### Database Deployment Options
+
+1. **Self-hosted Databases**
+   - Set `external: false` for automatic deployment
+   - Databases are deployed as StatefulSets with persistent storage
+   - Configuration managed through values.yaml
+
+2. **External Databases**
+   - Set `external: true` and provide connection details
+   - Manual database management required
+
 ## Uninstalling the Chart
 
 To uninstall/delete the `[RELEASE_NAME]` deployment:

--- a/charts/she/templates/clickhouse.yaml
+++ b/charts/she/templates/clickhouse.yaml
@@ -1,0 +1,64 @@
+{{- if .Values.enterprise.config.clickhouse.allowAuditLogs }}
+{{- if not .Values.enterprise.config.clickhouse.external }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ .Release.Name }}-clickhouse
+  labels:
+    app: {{ .Release.Name }}-clickhouse
+spec:
+  serviceName: {{ .Release.Name }}-clickhouse
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-clickhouse
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}-clickhouse
+    spec:
+      containers:
+      - name: clickhouse
+        image: {{ .Values.enterprise.config.clickhouse.clickhouse.image }}
+        env:
+        - name: CLICKHOUSE_USER
+          value: {{ .Values.enterprise.config.clickhouse.clickhouse.username }}
+        - name: CLICKHOUSE_PASSWORD
+          value: {{ .Values.enterprise.config.clickhouse.clickhouse.password }}
+        ports:
+        - containerPort: 8123
+          name: clickhousehttp
+        - containerPort: 9000
+          name: clickhouse
+        volumeMounts:
+        - name: clickhouse-data
+          mountPath: /var/lib/clickhouse
+  volumeClaimTemplates:
+  - metadata:
+      name: clickhouse-data
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: {{ .Values.enterprise.config.clickhouse.clickhouse.persistence.size }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-clickhouse
+  labels:
+    app: {{ .Release.Name }}-clickhouse
+spec:
+  ports:
+  - port: 8123
+    targetPort: clickhousehttp
+    protocol: TCP
+    name: clickhousehttp
+  - port: 9000
+    targetPort: clickhouse
+    protocol: TCP
+    name: clickhouse
+  selector:
+    app: {{ .Release.Name }}-clickhouse
+{{- end }}
+{{- end }}

--- a/charts/she/templates/configmap.yaml
+++ b/charts/she/templates/configmap.yaml
@@ -24,13 +24,9 @@ data:
 
   # Horizontal Scaling
   # Enable/Disable Horizontally Scaling
-  ENABLE_HORIZONTALLY_SCALING: {{ .Values.enterprise.config.horizontalScaling.enabled | quote }}
-  REDIS_ENABLED: {{ .Values.enterprise.config.redis.enabled | quote }}
-  {{- if .Values.enterprise.config.redis.enabled }}
-  REDIS_HOST: {{ .Values.enterprise.config.redis.host | quote }}
-  REDIS_PORT: {{ .Values.enterprise.config.redis.port | quote }}
-  REDIS_PASSWORD: {{ .Values.enterprise.config.redis.password | quote }}
-  REDIS_DATABASE: {{ .Values.enterprise.config.redis.database | quote }}
+  HORIZONTAL_SCALING: {{ .Values.enterprise.config.horizontalScaling.enabled | quote }}
+  {{- if .Values.enterprise.config.horizontalScaling.enabled }}
+  REDIS_URL: {{ if .Values.enterprise.config.redis.external }}{{ .Values.enterprise.config.redis.url | quote }}{{ else }}{{ printf "redis://%s-redis:6379/0" .Release.Name | quote }}{{ end }}
   {{- end }}
 
   # Auth Tokens
@@ -100,9 +96,9 @@ data:
   # ClickHouse Config
   ALLOW_AUDIT_LOGS: {{ .Values.enterprise.config.clickhouse.allowAuditLogs | quote }}
   ALLOW_WORKSPACE_ACTIVITY_LOGS: {{ .Values.enterprise.config.clickhouse.allowWorkspaceActivityLogs | quote }}
-  CLICKHOUSE_HOST: {{ .Values.enterprise.config.clickhouse.host | quote }}
-  CLICKHOUSE_USER: {{ .Values.enterprise.config.clickhouse.user | quote }}
-  CLICKHOUSE_PASSWORD: {{ .Values.enterprise.config.clickhouse.password | quote }}
+  CLICKHOUSE_HOST: {{ if .Values.enterprise.config.clickhouse.external }}{{ .Values.enterprise.config.clickhouse.host | quote }}{{ else }}{{ printf "http://%s-clickhouse:8123" .Release.Name | quote }}{{ end }}
+  CLICKHOUSE_USER: {{ if .Values.enterprise.config.clickhouse.external }}{{ .Values.enterprise.config.clickhouse.user | quote }}{{ else }}{{ .Values.enterprise.config.clickhouse.clickhouse.username }}{{ end }}
+  CLICKHOUSE_PASSWORD: {{ if .Values.enterprise.config.clickhouse.external }}{{ .Values.enterprise.config.clickhouse.password | quote }}{{ else }}{{ .Values.enterprise.config.clickhouse.clickhouse.password }}{{ end }}
 
   # Enterprise Config
   VITE_ALLOWED_AUTH_PROVIDERS: {{ .Values.enterprise.config.auth.allowedProviders | quote }}

--- a/charts/she/templates/hpa.yaml
+++ b/charts/she/templates/hpa.yaml
@@ -1,6 +1,6 @@
 # templates/hpa.yaml
 {{- if .Values.enterprise.config.horizontalScaling.enabled }}
-apiVersion: horizontalScaling/v2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ .Release.Name }}-hpa

--- a/charts/she/templates/redis.yaml
+++ b/charts/she/templates/redis.yaml
@@ -1,0 +1,56 @@
+{{- if .Values.enterprise.config.horizontalScaling.enabled }}
+{{- if not .Values.enterprise.config.redis.external }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ .Release.Name }}-redis
+  labels:
+    app: {{ .Release.Name }}-redis
+spec:
+  serviceName: {{ .Release.Name }}-redis
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-redis
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}-redis
+    spec:
+      containers:
+      - name: redis
+        image: {{ .Values.enterprise.config.redis.redis.image }}
+        env:
+        - name: REDIS_PASSWORD
+          value: {{ .Values.enterprise.config.redis.redis.password }}
+        ports:
+        - containerPort: 6379
+          name: redis
+        volumeMounts:
+        - name: redis-data
+          mountPath: /data
+  volumeClaimTemplates:
+  - metadata:
+      name: redis-data
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: {{ .Values.enterprise.config.redis.redis.persistence.size }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-redis
+  labels:
+    app: {{ .Release.Name }}-redis
+spec:
+  ports:
+  - port: 6379
+    targetPort: redis
+    protocol: TCP
+    name: redis
+  selector:
+    app: {{ .Release.Name }}-redis
+{{- end }}
+{{- end }}

--- a/charts/she/values.yaml
+++ b/charts/she/values.yaml
@@ -59,11 +59,13 @@ enterprise:
       targetMemoryUtilizationPercentage: 80
 
     redis:
-      enabled: false
-      host: "redis.example.com"
-      port: 6379
-      password: "password"
-      database: 1
+      external: false
+      url: "redis://username:password@hostname:port/database"
+      redis:
+        image: redis:6.2
+        password: redispassword
+        persistence:
+          size: 5Gi
 
     authjwt:
       sessionSecret: "dummySessionSecret"
@@ -133,11 +135,18 @@ enterprise:
         scope: "identify email"
 
     clickhouse:
+      external: false
       allowAuditLogs: false
       allowWorkspaceActivityLogs: false
       host: "https://example.com:8443"
       user: "default"
       password: "password"
+      clickhouse:
+        image: clickhouse/clickhouse-server:24.8
+        username: default
+        password: ""
+        persistence:
+          size: 10Gi
 
     enterprise:
       licenseKey: "dummyLicenseKey"


### PR DESCRIPTION
This PR adds Helm chart configurations for Redis and ClickHouse deployments, supporting both self-hosted and external database configurations. It includes stateful deployments with persistent storage and configurable connection settings.

**Key Changes**
* Added new template files for Redis and ClickHouse deployments
* Implemented StatefulSet configurations with persistent volume claims
* Added service definitions for both databases
* Configured conditional deployment based on external/internal database settings
* Updated configmap with dynamic database connection settings
* Added support for audit logs and workspace activity logging configuration