### PR TITLE
Removed deprecated annotation

### DIFF
--- a/charts/shc/templates/ingress.yaml
+++ b/charts/shc/templates/ingress.yaml
@@ -16,7 +16,6 @@ metadata:
     appgw.ingress.kubernetes.io/use-private-ip: "false"
     {{- else }}
     # Default ingress annotations for unspecified cloud provider
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
     {{- end }}
 spec:


### PR DESCRIPTION
Hey ! 

I've removed the kubernetes.io/ingress.class from the non-cloud deployment path. 
This one is deprecated (https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122) and causes issue with regular non modified k8s v1.31.5.

Not touching the cloud version since they might use it for something ie. GKE does this