### PR TITLE
Add option for custom Ingress annotations

### DIFF
--- a/charts/shc/README.md
+++ b/charts/shc/README.md
@@ -34,6 +34,7 @@ Update the URLs for mainHost, backendHost, adminHost and related urls in the `va
     mainHost: frontend.yourdomain.com
     adminHost: admin.yourdomain.com
     backendHost: backend.yourdomain.com
+    annotations: {}
 ```
 when **subpath is enabled**. Only update the mainHost and related urls:
 ```yaml
@@ -58,6 +59,7 @@ when **subpath is enabled**. Only update the mainHost and related urls:
     # - Main: yourdomain.com
     # - Backend: yourdomain.com/backend
     # - Admin: yourdomain.com/admin
+    annotations: {}
 ```
 
 ## Configuration

--- a/charts/shc/templates/ingress.yaml
+++ b/charts/shc/templates/ingress.yaml
@@ -19,6 +19,9 @@ metadata:
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
     {{- end }}
+    {{- range $key, $value := .Values.ingress.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
 spec:
   ingressClassName: {{ .Values.service.ingress.className | default "nginx" }}
   

--- a/charts/shc/templates/ingress.yaml
+++ b/charts/shc/templates/ingress.yaml
@@ -19,8 +19,8 @@ metadata:
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
     {{- end }}
-    {{- range $key, $value := .Values.ingress.annotations }}
-    {{ $key }}: {{ $value | quote }}
+    {{- with .Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
   ingressClassName: {{ .Values.service.ingress.className | default "nginx" }}

--- a/charts/shc/values.yaml
+++ b/charts/shc/values.yaml
@@ -145,7 +145,7 @@ service:
     adminHost: admin.example.com
     backendHost: backend.example.com
     className: nginx # nginx, alb, traefik
-    annotatios: {}
+    annotations: {}
 
   # TLS Configuration
   tls:

--- a/charts/shc/values.yaml
+++ b/charts/shc/values.yaml
@@ -145,6 +145,7 @@ service:
     adminHost: admin.example.com
     backendHost: backend.example.com
     className: nginx # nginx, alb, traefik
+    annotatios: {}
 
   # TLS Configuration
   tls:


### PR DESCRIPTION
Custom annotation are useful to automatically generate a certificate with `cert-manager`, or to create a DNS record with `external-dns` and more.