### PR TITLE
Allow to specify StorageClass for internal Postgres

### DIFF
--- a/charts/shc/templates/postgresql.yaml
+++ b/charts/shc/templates/postgresql.yaml
@@ -42,9 +42,9 @@ spec:
       accessModes: [ "ReadWriteOnce" ]
       {{- if .Values.community.config.postgresql.persistence.storageClass }}
       {{- if (eq "-" .Values.community.config.postgresql.persistence.storageClass) }}
-        storageClassName: ""
+      storageClassName: ""
       {{- else }}
-        storageClassName: "{{ .Values.community.config.postgresql.persistence.storageClass }}"
+      storageClassName: "{{ .Values.community.config.postgresql.persistence.storageClass }}"
       {{- end }}
       {{- end }}
       resources:

--- a/charts/shc/templates/postgresql.yaml
+++ b/charts/shc/templates/postgresql.yaml
@@ -40,6 +40,11 @@ spec:
       name: postgresql-data
     spec:
       accessModes: [ "ReadWriteOnce" ]
+      {{- if .Values.community.config.postgresql.persistence.storageClass }}
+      {{- if (eq "-" .Values.community.config.postgresql.persistence.storageClass) }}
+        storageClassName: ""
+      {{- else }}
+        storageClassName: "{{ .Values.community.config.postgresql.persistence.storageClass }}"
       resources:
         requests:
           storage: {{ .Values.community.config.postgresql.persistence.size }}

--- a/charts/shc/templates/postgresql.yaml
+++ b/charts/shc/templates/postgresql.yaml
@@ -45,6 +45,8 @@ spec:
         storageClassName: ""
       {{- else }}
         storageClassName: "{{ .Values.community.config.postgresql.persistence.storageClass }}"
+      {{- end }}
+      {{- end }}
       resources:
         requests:
           storage: {{ .Values.community.config.postgresql.persistence.size }}

--- a/charts/shc/values.yaml
+++ b/charts/shc/values.yaml
@@ -27,6 +27,7 @@ community:
       image: postgres:15
       persistence:
         size: 8Gi
+        storageClass: ""
       database: hoppscotchCommunity
       username: hoppscotch
       password: hoppscotch123


### PR DESCRIPTION
There are occasion where the storageClass must be different from the main hoppscotch deployment.
This PR simply allows to specify the StorageClass for the Posgres StatefulSet.