### PR TITLE
Use Secret for sensitive data and allow to use ExistingSecret

### DIFF
--- a/charts/shc/templates/configmap.yaml
+++ b/charts/shc/templates/configmap.yaml
@@ -3,9 +3,6 @@ kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-community-config
 data:
-  # Database
-  DATABASE_URL: {{ if .Values.community.config.database.external }}{{ .Values.community.config.database.url | quote }}{{ else }}{{ printf "postgres://%s:%s@%s-postgresql:5432/%s?sslmode=disable" .Values.community.config.postgresql.username .Values.community.config.postgresql.password .Release.Name .Values.community.config.postgresql.database | quote }}{{ end }}
-
   # Mailer
   MAILER_SMTP_ENABLE: {{ .Values.community.config.mailer.enable | quote }}
   MAILER_USE_CUSTOM_CONFIGS: {{ .Values.community.config.mailer.useCustomConfigs | quote }}

--- a/charts/shc/templates/configmap.yaml
+++ b/charts/shc/templates/configmap.yaml
@@ -42,25 +42,6 @@ data:
   REDIRECT_URL: {{ .Values.community.config.urls.redirect | quote }}
   WHITELISTED_ORIGINS: {{ .Values.community.config.urls.whitelistedOrigins | quote }}
 
-  # Google Auth
-  GOOGLE_CLIENT_ID: {{ .Values.community.config.auth.google.clientId | quote }}
-  GOOGLE_CLIENT_SECRET: {{ .Values.community.config.auth.google.clientSecret | quote }}
-  GOOGLE_CALLBACK_URL: {{ .Values.community.config.auth.google.callbackUrl | quote }}
-  GOOGLE_SCOPE: {{ .Values.community.config.auth.google.scope | quote }}
-
-  # Github Auth
-  GITHUB_CLIENT_ID: {{ .Values.community.config.auth.github.clientId | quote }}
-  GITHUB_CLIENT_SECRET: {{ .Values.community.config.auth.github.clientSecret | quote }}
-  GITHUB_CALLBACK_URL: {{ .Values.community.config.auth.github.callbackUrl | quote }}
-  GITHUB_SCOPE: {{ .Values.community.config.auth.github.scope | quote }}
-
-  # Microsoft Auth
-  MICROSOFT_CLIENT_ID: {{ .Values.community.config.auth.microsoft.clientId | quote }}
-  MICROSOFT_CLIENT_SECRET: {{ .Values.community.config.auth.microsoft.clientSecret | quote }}
-  MICROSOFT_CALLBACK_URL: {{ .Values.community.config.auth.microsoft.callbackUrl | quote }}
-  MICROSOFT_SCOPE: {{ .Values.community.config.auth.microsoft.scope | quote }}
-  MICROSOFT_TENANT: {{ .Values.community.config.auth.microsoft.tenant | quote }}
-
   # community Config
   VITE_ALLOWED_AUTH_PROVIDERS: {{ .Values.community.config.auth.allowedProviders | quote }}
   ENABLE_SUBPATH_BASED_ACCESS: {{ .Values.community.config.community.enableSubpathBasedAccess | quote }}

--- a/charts/shc/templates/deployment.yaml
+++ b/charts/shc/templates/deployment.yaml
@@ -32,7 +32,7 @@ spec:
           - /bin/sh
           - -c
           - |
-            until pg_isready -h {{ .Release.Name }}-postgresql -p 5432 -U {{ .Values.community.config.postgresql.username }}; do
+            until pg_isready -h {{ .Release.Name }}-postgresql -p 5432 -U {{ .Values.community.config.database.username }}; do
               sleep 2
             done
       {{- end }}
@@ -68,15 +68,28 @@ spec:
             - containerPort: {{ .Values.service.ports.admin.targetPort }}
               name: {{ .Values.service.ports.admin.name }}
           {{- end }}
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                {{- if .Values.community.config.database.existingSecret.urlKey }}
+                  name: {{ .Values.community.config.database.existingSecret.secretName | default (printf "%s-db" .Release.Name) }}
+                  key: {{ .Values.community.config.database.existingSecret.urlKey }}
+                {{- else }}
+                  name: {{ .Release.Name }}-community-secret
+                  key: DATABASE_URL
+                {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ .Release.Name }}-community-config
+            {{- if ne .Values.community.config.auth.allowedProviders "EMAIL" }}
             - secretRef:
               {{- if .Values.community.config.auth.existingSecret }}
                 name: {{ .Values.community.config.auth.existingSecret }}
               {{- else }}
-                name: {{ .Release.Name }}-auth-config
+                name: {{ .Release.Name }}-community-secret
               {{- end }}
+            {{- end}}
           resources:
             {{- toYaml .Values.community.resources | nindent 12 }}
       {{- if .Values.community.config.affinityEnabled }}

--- a/charts/shc/templates/deployment.yaml
+++ b/charts/shc/templates/deployment.yaml
@@ -71,6 +71,12 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ .Release.Name }}-community-config
+            - secretRef:
+              {{- if .Values.community.config.auth.existingSecret }}
+                name: {{ .Values.community.config.auth.existingSecret }}
+              {{- else }}
+                name: {{ .Release.Name }}-auth-config
+              {{- end }}
           resources:
             {{- toYaml .Values.community.resources | nindent 12 }}
       {{- if .Values.community.config.affinityEnabled }}

--- a/charts/shc/templates/migration-job.yaml
+++ b/charts/shc/templates/migration-job.yaml
@@ -23,10 +23,20 @@ spec:
           - -c
           - |
             echo "Waiting for PostgreSQL..."
-            until pg_isready -h {{ .Release.Name }}-postgresql -p 5432 -U {{ .Values.community.config.postgresql.username }}; do
+            until pg_isready -h {{ .Release.Name }}-postgresql -p 5432 -U $POSTGRES_USER; do
               sleep 2
             done
             echo "PostgreSQL is ready"
+        env:
+          - name: POSTGRES_USER
+            {{- if .Values.community.config.database.existingSecret.usernameKey }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.community.config.database.existingSecret.secretName | default (printf "%s-db" .Release.Name) }}
+                key: {{ .Values.community.config.database.existingSecret.usernameKey }}
+            {{- else }}
+            value: {{ .Values.community.config.database.username | quote }}
+            {{- end }}
       {{- end }}
       containers:
       - name: db-migration
@@ -36,11 +46,16 @@ spec:
           - -c
           - |
             echo "Running database migrations..."
+            export DATABASE_URL="$DATABASE_URL&schema=public"
             pnpx prisma migrate deploy
         env:
           - name: DATABASE_URL
-            {{- if .Values.community.config.database.external }}
-            value: {{ .Values.community.config.database.url | quote }}
-            {{- else }}
-            value: "postgresql://{{ .Values.community.config.postgresql.username }}:{{ .Values.community.config.postgresql.password }}@{{ .Release.Name }}-postgresql:5432/{{ .Values.community.config.postgresql.database }}?schema=public"
-            {{- end }}
+            valueFrom:
+              secretKeyRef:
+              {{- if .Values.community.config.database.existingSecret.urlKey }}
+                name: {{ .Values.community.config.database.existingSecret.secretName | default (printf "%s-db" .Release.Name) }}
+                key: {{ .Values.community.config.database.existingSecret.urlKey }}
+              {{- else }}
+                name: {{ .Release.Name }}-community-secret
+                key: DATABASE_URL
+              {{- end }}

--- a/charts/shc/templates/postgresql.yaml
+++ b/charts/shc/templates/postgresql.yaml
@@ -21,31 +21,31 @@ spec:
         image: {{ .Values.community.config.postgresql.image }}
         env:
         - name: POSTGRES_DB
-          {{- if .Values.community.config.postgresql.existingSecret.databaseKey }}
+          {{- if .Values.community.config.database.existingSecret.databaseKey }}
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.community.config.postgresql.existingSecret.secretName | default (printf "%s-db" .Release.Name) }}
-              key: {{ .Values.community.config.postgresql.existingSecret.databaseKey }}
+              name: {{ .Values.community.config.database.existingSecret.secretName | default (printf "%s-db" .Release.Name) }}
+              key: {{ .Values.community.config.database.existingSecret.databaseKey }}
           {{- else }}
-          value: {{ .Values.community.config.postgresql.database | quote }}
+          value: {{ .Values.community.config.database.database | quote }}
           {{- end }}
         - name: POSTGRES_USER
-          {{- if .Values.community.config.postgresql.existingSecret.usernameKey }}
+          {{- if .Values.community.config.database.existingSecret.usernameKey }}
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.community.config.postgresql.existingSecret.secretName | default (printf "%s-db" .Release.Name) }}
-              key: {{ .Values.community.config.postgresql.existingSecret.usernameKey }}
+              name: {{ .Values.community.config.database.existingSecret.secretName | default (printf "%s-db" .Release.Name) }}
+              key: {{ .Values.community.config.database.existingSecret.usernameKey }}
           {{- else }}
-          value: {{ .Values.community.config.postgresql.username | quote }}
+          value: {{ .Values.community.config.database.username | quote }}
           {{- end }}
         - name: POSTGRES_PASSWORD
-          {{- if .Values.community.config.postgresql.existingSecret.passwordKey }}
+          {{- if .Values.community.config.database.existingSecret.passwordKey }}
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.community.config.postgresql.existingSecret.secretName | default (printf "%s-db" .Release.Name) }}
-              key: {{ .Values.community.config.postgresql.existingSecret.passwordKey }}
+              name: {{ .Values.community.config.database.existingSecret.secretName | default (printf "%s-db" .Release.Name) }}
+              key: {{ .Values.community.config.database.existingSecret.passwordKey }}
           {{- else }}
-          value: {{ .Values.community.config.postgresql.password | quote }}
+          value: {{ .Values.community.config.database.password | quote }}
           {{- end }}
         - name: PGDATA
           value: /var/lib/postgresql/data/pgdata

--- a/charts/shc/templates/postgresql.yaml
+++ b/charts/shc/templates/postgresql.yaml
@@ -21,11 +21,32 @@ spec:
         image: {{ .Values.community.config.postgresql.image }}
         env:
         - name: POSTGRES_DB
-          value: {{ .Values.community.config.postgresql.database }}
+          {{- if .Values.community.config.postgresql.existingSecret.databaseKey }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.community.config.postgresql.existingSecret.secretName | default (printf "%s-db" .Release.Name) }}
+              key: {{ .Values.community.config.postgresql.existingSecret.databaseKey }}
+          {{- else }}
+          value: {{ .Values.community.config.postgresql.database | quote }}
+          {{- end }}
         - name: POSTGRES_USER
-          value: {{ .Values.community.config.postgresql.username }}
+          {{- if .Values.community.config.postgresql.existingSecret.usernameKey }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.community.config.postgresql.existingSecret.secretName | default (printf "%s-db" .Release.Name) }}
+              key: {{ .Values.community.config.postgresql.existingSecret.usernameKey }}
+          {{- else }}
+          value: {{ .Values.community.config.postgresql.username | quote }}
+          {{- end }}
         - name: POSTGRES_PASSWORD
-          value: {{ .Values.community.config.postgresql.password }}
+          {{- if .Values.community.config.postgresql.existingSecret.passwordKey }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.community.config.postgresql.existingSecret.secretName | default (printf "%s-db" .Release.Name) }}
+              key: {{ .Values.community.config.postgresql.existingSecret.passwordKey }}
+          {{- else }}
+          value: {{ .Values.community.config.postgresql.password | quote }}
+          {{- end }}
         - name: PGDATA
           value: /var/lib/postgresql/data/pgdata
         ports:

--- a/charts/shc/templates/postgresql.yaml
+++ b/charts/shc/templates/postgresql.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: postgresql
-        image: {{ .Values.community.config.postgresql.image }}
+        image: {{ .Values.community.config.database.postgresql.image }}
         env:
         - name: POSTGRES_DB
           {{- if .Values.community.config.database.existingSecret.databaseKey }}
@@ -61,9 +61,16 @@ spec:
       name: postgresql-data
     spec:
       accessModes: [ "ReadWriteOnce" ]
+      {{- if .Values.community.config.database.postgresql.persistence.storageClass }}
+      {{- if (eq "-" .Values.community.config.database.postgresql.persistence.storageClass) }}
+      storageClassName: ""
+      {{- else }}
+      storageClassName: "{{ .Values.community.config.database.postgresql.persistence.storageClass }}"
+      {{- end }}
+      {{- end }}
       resources:
         requests:
-          storage: {{ .Values.community.config.postgresql.persistence.size }}
+          storage: {{ .Values.community.config.database.postgresql.persistence.size }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/shc/templates/secret.yaml
+++ b/charts/shc/templates/secret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Release.Name }}-community-secret
+  name: {{ .Release.Name }}-env
   namespace: {{ .Release.Namespace | quote }}
 type: Opaque
 data:

--- a/charts/shc/templates/secret.yaml
+++ b/charts/shc/templates/secret.yaml
@@ -1,0 +1,28 @@
+{{- if not .Values.community.config.auth.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-auth-config
+  namespace: {{ .Release.Namespace | quote }}
+type: Opaque
+data:
+  {{- if not .Values.community.config.auth.existingSecret }}
+  GOOGLE_CLIENT_ID: {{ .Values.community.config.auth.google.clientId | b64enc | quote }}
+  GOOGLE_CLIENT_SECRET: {{ .Values.community.config.auth.google.clientSecret | b64enc | quote }}
+  GOOGLE_CALLBACK_URL: {{ .Values.community.config.auth.google.callbackUrl | b64enc | quote }}
+  GOOGLE_SCOPE: {{ .Values.community.config.auth.google.scope | b64enc | quote }}
+
+  # Github Auth
+  GITHUB_CLIENT_ID: {{ .Values.community.config.auth.github.clientId | b64enc | quote }}
+  GITHUB_CLIENT_SECRET: {{ .Values.community.config.auth.github.clientSecret | b64enc | quote }}
+  GITHUB_CALLBACK_URL: {{ .Values.community.config.auth.github.callbackUrl | b64enc | quote }}
+  GITHUB_SCOPE: {{ .Values.community.config.auth.github.scope | b64enc | quote }}
+
+  # Microsoft Auth
+  MICROSOFT_CLIENT_ID: {{ .Values.community.config.auth.microsoft.clientId | b64enc | quote }}
+  MICROSOFT_CLIENT_SECRET: {{ .Values.community.config.auth.microsoft.clientSecret | b64enc | quote }}
+  MICROSOFT_CALLBACK_URL: {{ .Values.community.config.auth.microsoft.callbackUrl | b64enc | quote }}
+  MICROSOFT_SCOPE: {{ .Values.community.config.auth.microsoft.scope | b64enc | quote }}
+  MICROSOFT_TENANT: {{ .Values.community.config.auth.microsoft.tenant | b64enc | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/shc/templates/secret.yaml
+++ b/charts/shc/templates/secret.yaml
@@ -1,12 +1,20 @@
-{{- if not .Values.community.config.auth.existingSecret }}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Release.Name }}-auth-config
+  name: {{ .Release.Name }}-community-secret
   namespace: {{ .Release.Namespace | quote }}
 type: Opaque
 data:
+{{- if not (and (.Values.community.config.database.existingSecret.enabled) (.Values.community.config.database.existingSecret.urlKey) ) }}
+  {{- if .Values.community.config.database.url }}
+  DATABASE_URL: {{ .Values.community.config.database.url | b64enc | quote }}
+  {{- else }}
+  DATABASE_URL: {{ printf "postgres://%s:%s@%s-postgresql:5432/%s?sslmode=%s" .Values.community.config.database.username .Values.community.config.database.password .Release.Name .Values.community.config.database.database .Values.community.config.database.ssl | b64enc | quote }}
+  {{- end}}
+{{- end }}
+
+{{- if not .Values.community.config.auth.existingSecret }}
   GOOGLE_CLIENT_ID: {{ .Values.community.config.auth.google.clientId | b64enc | quote }}
   GOOGLE_CLIENT_SECRET: {{ .Values.community.config.auth.google.clientSecret | b64enc | quote }}
   GOOGLE_CALLBACK_URL: {{ .Values.community.config.auth.google.callbackUrl | b64enc | quote }}
@@ -26,7 +34,7 @@ data:
   MICROSOFT_TENANT: {{ .Values.community.config.auth.microsoft.tenant | b64enc | quote }}
 {{- end }}
 
-{{- if not .Values.community.config.postgresql.existingSecret.enabled }}
+{{- if not .Values.community.config.database.existingSecret.enabled }}
 ---
 apiVersion: v1
 kind: Secret
@@ -35,11 +43,6 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
 type: Opaque
 data:
-  {{- if .Values.community.config.database.external }}
-  db-url: {{ .Values.community.config.database.url | b64enc | quote }}
-  {{- else }}
-  db-url: {{ printf "postgresql://%s:%s@%s-postgresql:5432/%s?schema=public" .Values.community.config.postgresql.username .Values.community.config.postgresql.password .Release.Name .Values.community.config.postgresql.database }}
-  {{- end }}
-  db-username: {{ .Values.community.config.postgresql.username | b64enc | quote }}
-  db-password: {{ .Values.community.config.postgresql.password | b64enc | quote }}
+  db-username: {{ .Values.community.config.database.username | b64enc | quote }}
+  db-password: {{ .Values.community.config.database.password | b64enc | quote }}
 {{- end }}

--- a/charts/shc/templates/secret.yaml
+++ b/charts/shc/templates/secret.yaml
@@ -7,7 +7,6 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
 type: Opaque
 data:
-  {{- if not .Values.community.config.auth.existingSecret }}
   GOOGLE_CLIENT_ID: {{ .Values.community.config.auth.google.clientId | b64enc | quote }}
   GOOGLE_CLIENT_SECRET: {{ .Values.community.config.auth.google.clientSecret | b64enc | quote }}
   GOOGLE_CALLBACK_URL: {{ .Values.community.config.auth.google.callbackUrl | b64enc | quote }}
@@ -25,7 +24,6 @@ data:
   MICROSOFT_CALLBACK_URL: {{ .Values.community.config.auth.microsoft.callbackUrl | b64enc | quote }}
   MICROSOFT_SCOPE: {{ .Values.community.config.auth.microsoft.scope | b64enc | quote }}
   MICROSOFT_TENANT: {{ .Values.community.config.auth.microsoft.tenant | b64enc | quote }}
-  {{- end }}
 {{- end }}
 
 {{- if not .Values.community.config.postgresql.existingSecret.enabled }}
@@ -37,6 +35,11 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
 type: Opaque
 data:
+  {{- if .Values.community.config.database.external }}
+  db-url: {{ .Values.community.config.database.url | b64enc | quote }}
+  {{- else }}
+  db-url: {{ printf "postgresql://%s:%s@%s-postgresql:5432/%s?schema=public" .Values.community.config.postgresql.username .Values.community.config.postgresql.password .Release.Name .Values.community.config.postgresql.database }}
+  {{- end }}
   db-username: {{ .Values.community.config.postgresql.username | b64enc | quote }}
   db-password: {{ .Values.community.config.postgresql.password | b64enc | quote }}
 {{- end }}

--- a/charts/shc/templates/secret.yaml
+++ b/charts/shc/templates/secret.yaml
@@ -1,4 +1,5 @@
 {{- if not .Values.community.config.auth.existingSecret }}
+---
 apiVersion: v1
 kind: Secret
 metadata:
@@ -25,4 +26,17 @@ data:
   MICROSOFT_SCOPE: {{ .Values.community.config.auth.microsoft.scope | b64enc | quote }}
   MICROSOFT_TENANT: {{ .Values.community.config.auth.microsoft.tenant | b64enc | quote }}
   {{- end }}
+{{- end }}
+
+{{- if not .Values.community.config.postgresql.existingSecret.enabled }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-db
+  namespace: {{ .Release.Namespace | quote }}
+type: Opaque
+data:
+  db-username: {{ .Values.community.config.postgresql.username | b64enc | quote }}
+  db-password: {{ .Values.community.config.postgresql.password | b64enc | quote }}
 {{- end }}

--- a/charts/shc/values.yaml
+++ b/charts/shc/values.yaml
@@ -22,11 +22,8 @@ community:
   config:
     database:
       external: false # Flag to use external DB, if false, it will use the internal postgresql created by the helm chart
-      url: "postgres://user:password@hostname:port/database?sslmode=require" # External database URL if provided
-    postgresql:
-      image: postgres:15
-      persistence:
-        size: 8Gi
+      url: "" # "postgres://user:password@hostname:port/database?sslmode=require" Overwrite default url created
+      ssl: enable
       database: hoppscotchCommunity
       username: hoppscotch
       password: hoppscotch123
@@ -34,10 +31,16 @@ community:
       existingSecret:
         enabled: false
         # secretName: hoppscotch-db
+        databaseKey: db-name
         usernameKey: db-username
         passwordKey: db-password
-        urlKey: db-url
-        # databaseKey: db-name
+        urlKey: "" # db-url, if specified, will use this value as url for connection
+
+      postgresql:
+        image: postgres:15
+        persistence:
+          size: 8Gi
+          storageClass: ""
 
 
     mailer:
@@ -81,7 +84,7 @@ community:
       whitelistedOrigins: "http://backend.example.com,http://frontend.example.com,http://admin.example.com"
 
     auth:
-      allowedProviders: "GOOGLE,MICROSOFT,GITHUB,EMAIL"
+      allowedProviders: "EMAIL" # "GOOGLE,MICROSOFT,GITHUB,EMAIL"
 
       existingSecret: ""
       google:

--- a/charts/shc/values.yaml
+++ b/charts/shc/values.yaml
@@ -88,23 +88,23 @@ community:
 
       existingSecret: ""
       google:
-        clientId: "dummyGoogleClientId"
-        clientSecret: "dummyGoogleClientSecret"
-        callbackUrl: "http://backend.example.com/v1/auth/google/callback"
-        scope: "email,profile"
+        clientId:  "" # "dummyGoogleClientId"
+        clientSecret:  "" # "dummyGoogleClientSecret"
+        callbackUrl:  "" # "http://backend.example.com/v1/auth/google/callback"
+        scope:  "" # "email,profile"
 
       github:
-        clientId: "dummyGithubClientId"
-        clientSecret: "dummyGithubClientSecret"
-        callbackUrl: "http://backend.example.com/v1/auth/github/callback"
-        scope: "user:email"
+        clientId:  "" # "dummyGithubClientId"
+        clientSecret:  "" # "dummyGithubClientSecret"
+        callbackUrl:  "" # "http://backend.example.com/v1/auth/github/callback"
+        scope:  "" # "user:email"
 
       microsoft:
-        clientId: "dummyMicrosoftClientId"
-        clientSecret: "dummyMicrosoftClientSecret"
-        callbackUrl: "http://backend.example.com/v1/auth/microsoft/callback"
-        scope: "user.read"
-        tenant: "dummyTenantId"
+        clientId:  "" # "dummyMicrosoftClientId"
+        clientSecret:  "" # "dummyMicrosoftClientSecret"
+        callbackUrl:  "" # "http://backend.example.com/v1/auth/microsoft/callback"
+        scope:  "" # "user.read"
+        tenant:  "" # "dummyTenantId"
 
     community:
       enableSubpathBasedAccess: false

--- a/charts/shc/values.yaml
+++ b/charts/shc/values.yaml
@@ -31,6 +31,14 @@ community:
       username: hoppscotch
       password: hoppscotch123
 
+      existingSecret:
+        enabled: false
+        # secretName: nameofsecret
+        usernameKey: db-username
+        passwordKey: db-password
+        # databaseKey: db-name
+
+
     mailer:
       enable: false
       useCustomConfigs: false
@@ -74,6 +82,7 @@ community:
     auth:
       allowedProviders: "GOOGLE,MICROSOFT,GITHUB,EMAIL"
 
+      existingSecret: ""
       google:
         clientId: "dummyGoogleClientId"
         clientSecret: "dummyGoogleClientSecret"

--- a/charts/shc/values.yaml
+++ b/charts/shc/values.yaml
@@ -33,9 +33,10 @@ community:
 
       existingSecret:
         enabled: false
-        # secretName: nameofsecret
+        # secretName: hoppscotch-db
         usernameKey: db-username
         passwordKey: db-password
+        urlKey: db-url
         # databaseKey: db-name
 
 


### PR DESCRIPTION
Fix #9

A lot of sensitive data is currently set in a configMap, which is not ideal. Credentials should be placed in a Secret.
Also, there are situation where `values.yaml` should not contain any credentials (ex. in a flux env) and an existingSecret comes in handy. 