### PR TITLE
Set service type dynamically based on values

### DIFF
--- a/charts/shc/templates/service.yaml
+++ b/charts/shc/templates/service.yaml
@@ -9,9 +9,9 @@ metadata:
   annotations:
     {{- toYaml .Values.service.annotations | nindent 4 }}
 spec:
-  type: {{ ternary "ClusterIP" "LoadBalancer" .Values.service.ingress.enabled }}
+  type: {{ .Values.service.type }}
   
-  {{- if not .Values.service.ingress.enabled }}
+  {{- if eq .Values.service.type "LoadBalancer" }}
   loadBalancerIP: {{ .Values.global.externalIP }}
   externalTrafficPolicy: Cluster
   {{- end }}


### PR DESCRIPTION
Original commit: https://github.com/JakobStadlhuber/hoppscotch-helm-charts/commit/2b8af595df8c4bff89adfb4fba3951ab9f0d1586

Updated the service template to use `.Values.service.type` directly instead of a ternary operation. This change ensures better flexibility and aligns with user-defined configurations, particularly for LoadBalancer settings.

**Why?**

Without this patch, the chart is not usable in a situation where the service must be of type ClusterIP and an ingress that's managed external to this chart exposes the service externally.