### PR TITLE
[feature]: Host Helm charts on GitHub Pages and releases

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[Makefile]
+indent_style = tab

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -1,0 +1,30 @@
+name: Lint and test charts
+on: pull_request
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up Helm
+        uses: azure/setup-helm@v4.2.0
+        with:
+          version: v3.17.0
+      - uses: actions/setup-python@v5.3.0
+        with:
+          python-version: "3.x"
+          check-latest: true
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.7.0
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
+          if [[ -n "$changed" ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Run chart-testing (lint)
+        if: steps.list-changed.outputs.changed == 'true'
+        run: ct lint --config ct.yaml --lint-conf lintconf.yaml --target-branch ${{ github.event.repository.default_branch }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,26 @@
+name: Release charts
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "charts/*/Chart.yaml"
+jobs:
+  release:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.7.0
+        env:
+          CR_SKIP_EXISTING: true
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-# Environment variables
+.cr-release-packages/

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 .DEFAULT_GOAL := help
 
+.PHONY: clean
+clean: ## Clean up chart release packages
+	rm -rf .cr-release-packages
+
 .PHONY: help
 help: ## Show this help message
 	@echo "Usage: make [target]"
@@ -9,6 +13,7 @@ help: ## Show this help message
 
 .PHONY: install-deps-macos
 install-deps-macos: ## Install dependencies for MacOS
+	brew install chart-releaser
 	brew install chart-testing
 	brew install kind
 	brew install shellcheck
@@ -23,6 +28,10 @@ lint-charts: ## Lint charts
 .PHONY: lint-shell
 lint-shell: ## Lint shell scripts
 	find . -type f -name "*.sh" | xargs shellcheck
+
+.PHONY: package
+package: clean ## Package Helm charts
+	cr package charts/*
 
 .PHONY: test-e2e
 test-e2e: ## Run end-to-end tests

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ lint-shell: ## Lint shell scripts
 	find . -type f -name "*.sh" | xargs shellcheck
 
 .PHONY: package
-package: clean ## Package Helm charts
+package: clean ## Package charts
 	cr package charts/*
 
 .PHONY: test-e2e

--- a/Makefile
+++ b/Makefile
@@ -18,12 +18,44 @@ install-deps-macos: ## Install dependencies for MacOS
 	brew install kind
 	brew install shellcheck
 
+.PHONY: install-deps-linux
+install-deps-linux: ## Install dependencies for Linux
+	@echo "Installing Helm..."
+	curl -fsSL https://get.helm.sh/helm-v3.17.0-linux-amd64.tar.gz | tar xz && sudo mv linux-amd64/helm /usr/local/bin/ && rm -rf linux-amd64
+	@echo "Installing chart-testing..."
+	curl -fsSLo ct.tar.gz https://github.com/helm/chart-testing/releases/download/v3.10.1/chart-testing_3.10.1_linux_amd64.tar.gz && tar -xzf ct.tar.gz && sudo mv ct /usr/local/bin/ && rm ct.tar.gz
+	@echo "Installing chart-releaser..."
+	curl -fsSLo cr.tar.gz https://github.com/helm/chart-releaser/releases/download/v1.6.0/chart-releaser_1.6.0_linux_amd64.tar.gz && tar -xzf cr.tar.gz && sudo mv cr /usr/local/bin/ && rm cr.tar.gz
+	@echo "Installing kind..."
+	[ $$(uname -m) = x86_64 ] && curl -fsSLo ./kind https://kind.sigs.k8s.io/dl/v0.20.0/kind-linux-amd64 || curl -fsSLo ./kind https://kind.sigs.k8s.io/dl/v0.20.0/kind-linux-arm64
+	chmod +x ./kind && sudo mv ./kind /usr/local/bin/kind
+	@echo "Installing shellcheck..."
+	sudo apt-get update && sudo apt-get install -y shellcheck || (echo "Please install shellcheck manually for your Linux distribution" && exit 1)
+	@echo "Installing yamllint and yamale..."
+	sudo apt-get install -y python3-yamllint python3-yamale || (echo "Failed to install via apt, trying pipx..." && sudo apt-get install -y pipx && pipx install yamllint && pipx install yamale)
+	@echo "Installing chart-testing configuration..."
+	sudo mkdir -p /etc/ct
+	curl -fsSLo /tmp/chart_schema.yaml https://raw.githubusercontent.com/helm/chart-testing/main/etc/chart_schema.yaml
+	sudo mv /tmp/chart_schema.yaml /etc/ct/chart_schema.yaml
+	@echo "All dependencies installed successfully!"
+
+.PHONY: install-deps
+install-deps: ## Install dependencies (auto-detect OS)
+	@if [ "$$(uname)" = "Darwin" ]; then \
+		$(MAKE) install-deps-macos; \
+	elif [ "$$(uname)" = "Linux" ]; then \
+		$(MAKE) install-deps-linux; \
+	else \
+		echo "Unsupported operating system: $$(uname)"; \
+		exit 1; \
+	fi
+
 .PHONY: lint
 lint: lint-charts lint-shell ## Run all linters
 
 .PHONY: lint-charts
 lint-charts: ## Lint charts
-	ct lint
+	ct lint --config ct.yaml --lint-conf lintconf.yaml
 
 .PHONY: lint-shell
 lint-shell: ## Lint shell scripts

--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,20 @@ help: ## Show this help message
 .PHONY: install-deps-macos
 install-deps-macos: ## Install dependencies for MacOS
 	brew install chart-testing
+	brew install kind
+	brew install shellcheck
 
 .PHONY: lint
-lint: lint-charts ## Run all linters
+lint: lint-charts lint-shell ## Run all linters
 
 .PHONY: lint-charts
 lint-charts: ## Lint charts
 	ct lint
+
+.PHONY: lint-shell
+lint-shell: ## Lint shell scripts
+	find . -type f -name "*.sh" | xargs shellcheck
+
+.PHONY: test-e2e
+test-e2e: ## Run end-to-end tests
+	./test/test-e2e.sh

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+.DEFAULT_GOAL := help
+
+.PHONY: help
+help: ## Show this help message
+	@echo "Usage: make [target]"
+	@echo ""
+	@echo "Available Targets:"
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  %-15s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+.PHONY: install-deps-macos
+install-deps-macos: ## Install dependencies for MacOS
+	brew install chart-testing
+
+.PHONY: lint
+lint: lint-charts ## Run all linters
+
+.PHONY: lint-charts
+lint-charts: ## Lint charts
+	ct lint

--- a/README.md
+++ b/README.md
@@ -46,12 +46,14 @@
 <summary><b>Digital Ocean Installation</b></summary>
 
 ## Prerequisites
+
 - Digital Ocean account with administrative access
 - kubectl CLI tool
 - Helm 3.x installed
 - doctl installed
 
 ## Quick Install
+
 ```bash
 # Configure access
 export KUBECONFIG=path/to/k8s-config.yaml
@@ -59,12 +61,15 @@ export KUBECONFIG=path/to/k8s-config.yaml
 # (Optional) Install NGINX Ingress
 kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.8.2/deploy/static/provider/do/deploy.yaml
 
+# Add chart repository
+helm repo add hoppscotch https://hoppscotch.github.io/helm-charts
+
 # Deploy application
 ## Community
-helm install [RELEASE_NAME] ./charts/shc -f [path-to-values-file]
+helm install [RELEASE_NAME] hoppscotch/hoppscotch-community -f [path-to-values-file]
 
 ## Enterprise
-helm install [RELEASE_NAME] ./charts/she -f [path-to-values-file]
+helm install [RELEASE_NAME] hoppscotch/hoppscotch-enterprise -f [path-to-values-file]
 ```
 
 </details>
@@ -73,12 +78,14 @@ helm install [RELEASE_NAME] ./charts/she -f [path-to-values-file]
 <summary><b>GCP Installation</b></summary>
 
 ## Prerequisites
+
 - Google Cloud account with GKE access
 - gcloud CLI configured
 - kubectl CLI tool
 - Helm 3.x installed
 
 ## Quick Install
+
 ```bash
 # Configure cluster access
 gcloud container clusters get-credentials cluster-name --zone zone --project project-id
@@ -86,12 +93,15 @@ gcloud container clusters get-credentials cluster-name --zone zone --project pro
 # (Optional) Install NGINX Ingress
 kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.8.2/deploy/static/provider/cloud/deploy.yaml
 
+# Add chart repository
+helm repo add hoppscotch https://hoppscotch.github.io/helm-charts
+
 # Deploy application
 ## Community
-helm install [RELEASE_NAME] ./charts/shc -f [path-to-values-file]
+helm install [RELEASE_NAME] hoppscotch/hoppscotch-community -f [path-to-values-file]
 
 ## Enterprise
-helm install [RELEASE_NAME] ./charts/she -f [path-to-values-file]
+helm install [RELEASE_NAME] hoppscotch/hoppscotch-enterprise -f [path-to-values-file]
 ```
 
 </details>
@@ -111,11 +121,9 @@ Please contribute using [GitHub Flow](https://guides.github.com/introduction/flo
 
 Please read [`CONTRIBUTING`](CONTRIBUTING.md) for details on our [`CODE OF CONDUCT`](CODE_OF_CONDUCT.md), and the process for submitting pull requests to us.
 
-
 ## **Continuous Integration**
 
 We use [GitHub Actions](https://github.com/features/actions) for continuous integration.
-
 
 ## **Authors**
 

--- a/charts/shc/Chart.yaml
+++ b/charts/shc/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: hoppscotch
+name: hoppscotch-community
 description: A Helm chart for Hoppscotch Community Edition
 type: application
 version: 0.1.0

--- a/charts/shc/README.md
+++ b/charts/shc/README.md
@@ -35,7 +35,9 @@ Update the URLs for mainHost, backendHost, adminHost and related urls in the `va
     adminHost: admin.yourdomain.com
     backendHost: backend.yourdomain.com
 ```
+
 when **subpath is enabled**. Only update the mainHost and related urls:
+
 ```yaml
   urls:
     base: "http://yourdomain.com"
@@ -49,7 +51,7 @@ when **subpath is enabled**. Only update the mainHost and related urls:
     whitelistedOrigins: "http://yourdomain.com/backend,http://yourdomain.com,http://yourdomain.com/admin"
 
   enableSubpathBasedAccess: true
-  
+
   # Ingress Configuration
   ingress:
     enabled: true
@@ -88,7 +90,8 @@ service:
 Then install the chart with your custom values:
 
 ```bash
-helm install [RELEASE_NAME] ./charts/shc -f values.yaml
+helm repo add hoppscotch https://hoppscotch.github.io/helm-charts
+helm install [RELEASE_NAME] hoppscotch/hoppscotch-community -f values.yaml
 ```
 
 ## Uninstalling the Chart

--- a/charts/she/Chart.yaml
+++ b/charts/she/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: hoppscotch
+name: hoppscotch-enterprise
 description: A Helm chart for Hoppscotch Enterprise Edition
 type: application
 version: 0.1.0

--- a/charts/she/README.md
+++ b/charts/she/README.md
@@ -44,7 +44,9 @@ Update the URLs for mainHost, backendHost, adminHost and related urls in the `va
     adminHost: admin.yourdomain.com
     backendHost: backend.yourdomain.com
 ```
+
 when **subpath is enabled**. Only update the mainHost and related urls:
+
 ```yaml
   urls:
     base: "http://yourdomain.com"
@@ -58,7 +60,7 @@ when **subpath is enabled**. Only update the mainHost and related urls:
     whitelistedOrigins: "http://yourdomain.com/backend,http://yourdomain.com,http://yourdomain.com/admin"
 
   enableSubpathBasedAccess: true
-  
+
   # Ingress Configuration
   ingress:
     enabled: true
@@ -100,12 +102,14 @@ service:
 Then install the chart with your custom values:
 
 ```bash
-helm install [RELEASE_NAME] ./charts/she -f values.yaml
+helm repo add hoppscotch https://hoppscotch.github.io/helm-charts
+helm install [RELEASE_NAME] hoppscotch/hoppscotch-enterprise -f values.yaml
 ```
 
 ### Database Configuration
 
 #### ClickHouse Configuration
+
 ```yaml
 enterprise:
   config:
@@ -117,7 +121,7 @@ enterprise:
       host: "your-clickhouse-host"
       user: "your-clickhouse-user"
       password: "your-clickhouse-password"
-      
+
       # Self-hosted ClickHouse configuration
       clickhouse:
         image: "clickhouse/clickhouse-server:latest"
@@ -128,6 +132,7 @@ enterprise:
 ```
 
 #### Redis Configuration
+
 ```yaml
 enterprise:
   config:
@@ -138,7 +143,7 @@ enterprise:
       external: false
       host: "your-redis-host"
       password: "your-redis-password"
-      
+
       # Self-hosted Redis configuration
       redis:
         image: "redis:latest"
@@ -169,17 +174,20 @@ helm uninstall [RELEASE_NAME]
 ## Enterprise Support
 
 As an enterprise customer, you have access to:
+
 - Priority issue resolution
 - Custom feature requests
 - Implementation assistance
 
 Contact enterprise support through:
+
 - Enterprise Support Portal
 - Priority Email Support
 
 ## License Management
 
 Enterprise license management includes:
+
 - License renewal
 - Capacity management
 - Feature activation
@@ -187,6 +195,7 @@ Enterprise license management includes:
 ## Security and Compliance
 
 Enterprise security features include:
+
 - Access control
 - Audit logging
 - Enhanced security controls

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,0 +1,2 @@
+check-version-increment: false
+validate-maintainers: false

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,2 +1,4 @@
 check-version-increment: false
 validate-maintainers: false
+target-branch: main
+remote: origin

--- a/docs/general-guidelines.md
+++ b/docs/general-guidelines.md
@@ -26,30 +26,33 @@ Before deploying Hoppscotch using these Helm charts, ensure you have:
 
 The repository contains two main chart collections:
 
-1. **SHC (Community Edition)**
+1. **Hoppscotch Community**
    - Free and open-source version
    - Suitable for individual developers and small teams
    - Community-supported
 
-2. **SHE (Enterprise Edition)**
-   - Enhanced features for enterprise use
-   - Additional security and compliance features
-   - Professional support available
+2. **Hoppscotch Enterprise**
+    - Enhanced features for enterprise use
+    - Additional security and compliance features
+    - Professional support available
 
 ## Best Practices
 
 ### Security
+
 - Always review the values.yaml file before deployment
 - Use secret management solutions for sensitive data
 - Implement network policies as needed
 - Regular security audits and updates
 
 ### Performance
+
 - Configure resource requests and limits appropriately
 - Monitor resource utilization
 - Use horizontal pod autoscaling when needed
 
 ### High Availability
+
 - Deploy across multiple availability zones
 - Configure appropriate replica counts
 - Implement proper backup strategies
@@ -57,6 +60,7 @@ The repository contains two main chart collections:
 ## Support
 
 For support, you can:
+
 - Join our [Discord community](https://hoppscotch.io/discord)
 - Join our [Telegram group](https://hoppscotch.io/telegram)
 - Participate in [GitHub Discussions](https://github.com/hoppscotch/hoppscotch/discussions)

--- a/docs/shc-usage.md
+++ b/docs/shc-usage.md
@@ -5,6 +5,7 @@ This guide covers the installation and usage of the Community Edition of Hoppsco
 ## Features
 
 The Community Edition includes:
+
 - Basic Kubernetes deployment configurations
 - Community support
 
@@ -13,6 +14,7 @@ The Community Edition includes:
 ### Digital Ocean Installation
 
 1. **Prerequisites**
+
 ```bash
 # Required tools
 - Digital Ocean account with administrative access
@@ -21,6 +23,7 @@ The Community Edition includes:
 ```
 
 2. **Deployment Steps**
+
 ```bash
 # Configure access
 export KUBECONFIG=path/to/k8s-config.yaml
@@ -28,16 +31,20 @@ export KUBECONFIG=path/to/k8s-config.yaml
 # (Optional) Install NGINX Ingress
 kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.8.2/deploy/static/provider/do/deploy.yaml
 
+# Add chart repository
+helm repo add hoppscotch https://hoppscotch.github.io/helm-charts
+
 # Deploy application with default values
-helm install [RELEASE_NAME] ./charts/shc
+helm install [RELEASE_NAME] hoppscotch/hoppscotch-community
 
 # Deploy application with custom values file
-helm install [RELEASE_NAME] ./charts/shc -f [path-to-values-file]
+helm install [RELEASE_NAME] hoppscotch/hoppscotch-community -f [path-to-values-file]
 ```
 
 ### GCP Installation
 
 1. **Prerequisites**
+
 ```bash
 # Required tools
 - Google Cloud account with GKE access
@@ -47,6 +54,7 @@ helm install [RELEASE_NAME] ./charts/shc -f [path-to-values-file]
 ```
 
 2. **Deployment Steps**
+
 ```bash
 # Configure cluster access
 gcloud container clusters get-credentials cluster-name --zone zone --project project-id
@@ -54,16 +62,20 @@ gcloud container clusters get-credentials cluster-name --zone zone --project pro
 # (Optional) Install NGINX Ingress
 kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.8.2/deploy/static/provider/cloud/deploy.yaml
 
+# Add chart repository
+helm repo add hoppscotch https://hoppscotch.github.io/helm-charts
+
 # Deploy application with default values
-helm install [RELEASE_NAME] ./charts/shc
+helm install [RELEASE_NAME] hoppscotch/hoppscotch-community
 
 # Deploy application with custom values file
-helm install [RELEASE_NAME] ./charts/shc -f [path-to-values-file]
+helm install [RELEASE_NAME] hoppscotch/hoppscotch-community -f [path-to-values-file]
 ```
 
 ## Configuration
 
 ### Basic Configuration
+
 ```yaml
 # Example values.yaml
 replicaCount: 2
@@ -73,6 +85,7 @@ image:
 ```
 
 ### Advanced Configuration
+
 - Resource limits
 - Persistence settings
 - Service configurations
@@ -81,13 +94,15 @@ image:
 ## Upgrading
 
 To upgrade your deployment:
+
 ```bash
-helm upgrade [RELEASE_NAME] ./charts/shc -f [path-to-values-file]
+helm upgrade [RELEASE_NAME] hoppscotch/hoppscotch-community -f [path-to-values-file]
 ```
 
 ## Troubleshooting
 
 Common issues and solutions:
+
 1. Pod scheduling issues
 2. Resource constraints
 3. Network connectivity
@@ -96,6 +111,7 @@ Common issues and solutions:
 ## Community Support
 
 Get help from the community:
+
 - GitHub Discussions
 - Discord Channel
 - Telegram Group

--- a/docs/she-usage.md
+++ b/docs/she-usage.md
@@ -5,16 +5,18 @@ This guide covers the installation and usage of the Enterprise Edition of Hoppsc
 ## Enterprise Features
 
 Additional features beyond the Community Edition:
+
 - Enhanced scalability options
 - High availability configurations
 - Enterprise-grade support
-- Advanced monitoring 
+- Advanced monitoring
 
 ## Installation
 
 ### Digital Ocean Installation
 
 1. **Prerequisites**
+
 ```bash
 # Required tools
 - Digital Ocean account with administrative access
@@ -24,6 +26,7 @@ Additional features beyond the Community Edition:
 ```
 
 2. **Deployment Steps**
+
 ```bash
 # Configure access
 export KUBECONFIG=path/to/k8s-config.yaml
@@ -31,16 +34,20 @@ export KUBECONFIG=path/to/k8s-config.yaml
 # (Optional) Install NGINX Ingress
 kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.8.2/deploy/static/provider/do/deploy.yaml
 
+# Add chart repository
+helm repo add hoppscotch https://hoppscotch.github.io/helm-charts
+
 # Deploy application with default values
-helm install [RELEASE_NAME] ./charts/she
+helm install [RELEASE_NAME] hoppscotch/hoppscotch-enterprise
 
 # Deploy application with custom values file
-helm install [RELEASE_NAME] ./charts/she -f [path-to-values-file]
+helm install [RELEASE_NAME] hoppscotch/hoppscotch-enterprise -f [path-to-values-file]
 ```
 
 ### GCP Installation
 
 1. **Prerequisites**
+
 ```bash
 # Required tools
 - Google Cloud account with GKE access
@@ -50,6 +57,7 @@ helm install [RELEASE_NAME] ./charts/she -f [path-to-values-file]
 ```
 
 2. **Deployment Steps**
+
 ```bash
 # Configure cluster access
 gcloud container clusters get-credentials cluster-name --zone zone --project project-id
@@ -57,16 +65,20 @@ gcloud container clusters get-credentials cluster-name --zone zone --project pro
 # (Optional) Install NGINX Ingress
 kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.8.2/deploy/static/provider/cloud/deploy.yaml
 
+# Add chart repository
+helm repo add hoppscotch https://hoppscotch.github.io/helm-charts
+
 # Deploy application with default values
-helm install [RELEASE_NAME] ./charts/she
+helm install [RELEASE_NAME] hoppscotch/hoppscotch-enterprise
 
 # Deploy application with custom values file
-helm install [RELEASE_NAME] ./charts/she -f [path-to-values-file]
+helm install [RELEASE_NAME] hoppscotch/hoppscotch-enterprise -f [path-to-values-file]
 ```
 
 ## Enterprise Configuration
 
 ### Basic Configuration
+
 ```yaml
 # Example values.yaml
 replicaCount: 2
@@ -78,13 +90,15 @@ image:
 ## Upgrading
 
 To upgrade your deployment:
+
 ```bash
-helm upgrade [RELEASE_NAME] ./charts/she -f [path-to-values-file]
+helm upgrade [RELEASE_NAME] hoppscotch/hoppscotch-enterprise -f [path-to-values-file]
 ```
 
 ## Compliance and Auditing
 
 Enterprise features for compliance:
+
 - Audit logging
 - Compliance reporting
 - Access control
@@ -92,11 +106,14 @@ Enterprise features for compliance:
 ## Enterprise Support
 
 Contact enterprise support:
+
 - Dedicated support portal
 - Priority issue resolution
 - Custom feature requests
 
 ## License Management
+
 Managing your enterprise license:
+
 - License renewal
 - Adding capacity

--- a/lintconf.yaml
+++ b/lintconf.yaml
@@ -1,0 +1,3 @@
+rules:
+  comments:
+    min-spaces-from-content: 1

--- a/test/kind-cluster.yaml
+++ b/test/kind-cluster.yaml
@@ -1,0 +1,6 @@
+---
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+  - role: worker

--- a/test/test-e2e.sh
+++ b/test/test-e2e.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+readonly CLUSTER_NAME=chart-testing
+readonly CONTAINER_NAME=ct
+readonly CT_VERSION=v3.13.0
+readonly K8S_VERSION=v1.33.1
+
+cleanup() {
+  echo "Removing ct container..."
+  docker rm "${CONTAINER_NAME}" --force
+  echo "Deleting Kind cluster..."
+  kind delete cluster --name="${CLUSTER_NAME}"
+}
+
+create_kind_cluster() {
+  kind create cluster --name "${CLUSTER_NAME}" --config test/kind-cluster.yaml --image "kindest/node:${K8S_VERSION}" --wait 60s
+  docker exec "${CONTAINER_NAME}" mkdir /root/.kube
+  docker cp "${HOME}/.kube/config" "${CONTAINER_NAME}:/root/.kube/config"
+}
+
+install_charts() {
+  echo "Installing charts..."
+  docker exec "${CONTAINER_NAME}" ct install
+  echo
+}
+
+run_ct_container() {
+  echo "Running ct container..."
+  docker run --rm --interactive --detach --network host --name ct \
+    --volume "$(pwd)/ct.yaml:/etc/ct/ct.yaml" \
+    --volume "$(pwd):/workdir" \
+    --workdir /workdir \
+    "quay.io/helmpack/chart-testing:${CT_VERSION}" \
+    cat
+  echo
+}
+
+main() {
+  run_ct_container
+  trap cleanup EXIT
+  create_kind_cluster
+  install_charts
+}
+
+main


### PR DESCRIPTION
### What's changed

This PR implements hosting Helm charts on GitHub pages and releases and automates the testing and release process. This resolves issue https://github.com/hoppscotch/helm-charts/issues/26.

#### Chart Release

The `release.yaml` GitHub action uses [chart-releaser](https://github.com/helm/chart-releaser) to package charts, upload them as GitHub releases, and publish a chart repository index to the `gh_pages` branch. This will allow users to use https://hoppscotch.github.io/helm-charts as the chart repository.

```bash
helm repo add hoppscotch https://hoppscotch.github.io/helm-charts
helm install hoppscotch hoppscotch/hoppscotch-community
```

The release action triggers when a change to `charts/**/Chart.yaml` is pushed to `main`.

For a live version of this, see https://jonathanfoster.github.io/hoppscotch-helm-charts.

#### Chart Testing

The `lint-test.yaml` GitHub action uses [chart-testing]() to automate chart linting and testing. Only linting is enabled for now as the current chart installation fails due to pre-existing issues not introduced in this PR. Once these issues have been resolved, end-to-end testing can be enabled.

The end-to-end testing process is implemented in `test-e2e.sh`. The script creates a local Kind cluster and installs the Hoppscotch charts. This script may require additional updates and testing once the pre-existing issues are resolved.

The lint test action triggers on pull requests.

#### Local Testing & Release

A `Makefile` was added that includes scripts to run chart-releaser and chart-testing locally for development purposes. 

The `install-deps-macos` task can be used to install development dependencies.

```bash
make install-deps-macos
```

The `lint-charts` task can be used to run the chart-testing linter. `ct.yaml` and `lintconf.yaml` contain linter config settings.

```bash
make lint-charts
```

The `package` task can be used to run the chart-releaser packaging.

```bash
make package
```

### Notes to reviewers

- Edition was added to the chart names to avoid package name collisions (e.g., `hoppscotch-community`, `hoppscotch-enterprise`).
- GitHub pages must be enabled to support the final publishing step. This can be done by following instructions in the [Helm Chart Repository Guide](https://helm.sh/docs/topics/chart_repository/#github-pages-example).

