### PR TITLE
Fix default namespace overrides helm install namespace

### DIFF
--- a/charts/shc/values.yaml
+++ b/charts/shc/values.yaml
@@ -1,7 +1,7 @@
 # Global settings for the application
 global:
   externalIP: "0.0.0.0" # Example: "192.168.1.1"
-  namespace: "default" # Example: "hoppscotch"
+  namespace: "" # Example: "hoppscotch"
 
 # Community-specific settings
 community:

--- a/charts/she/values.yaml
+++ b/charts/she/values.yaml
@@ -1,7 +1,7 @@
 # Global settings for the application
 global:
   externalIP: "0.0.0.0" # Example: "192.168.1.1"
-  namespace: "default" # Example: "hoppscotch"
+  namespace: "" # Example: "hoppscotch"
 
 # Enterprise-specific settings
 enterprise:


### PR DESCRIPTION
### What's changed

This PR fixes issue https://github.com/hoppscotch/helm-charts/issues/30. The default namespace value is remove from `global.namespace` in `values.yaml`. 

### Note to reviewers

You can test this PR with the following steps.

1. Create Kind cluster

    ```bash
    kind create cluster
    ```

2. Install chart

    ```bash
    helm install hoppscotch ./charts/shc -n hoppscotch --create-namespace
    ```

3. Verify resources in helm install namespace

    ```bash
    kubectl get pods -n hoppscotch
    ```

4. Delete Kind cluster

    ```bash
    kind delete cluster
    ```