### PR TITLE
feat: Add resource limits to init container in database migration Job

### DIFF
--- a/charts/she/templates/deployment.yaml
+++ b/charts/she/templates/deployment.yaml
@@ -29,6 +29,8 @@ spec:
       {{- if not .Values.enterprise.config.database.external }}
       - name: wait-for-postgres
         image: postgres:15-alpine
+        resources:
+          {{- toYaml .Values.enterprise.initContainers.resources | nindent 10 }}
         command:
           - /bin/sh
           - -c
@@ -39,6 +41,8 @@ spec:
       {{- end }}
       - name: wait-for-migration
         image: bitnami/kubectl:latest
+        resources:
+          {{- toYaml .Values.enterprise.initContainers.resources | nindent 10 }}
         command:
           - /bin/sh
           - -c
@@ -77,7 +81,7 @@ spec:
           resources:
             {{- toYaml .Values.enterprise.resources | nindent 12 }}
       {{- if .Values.enterprise.config.affinityEnabled }}
-      affinity: 
+      affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:

--- a/charts/she/templates/migration-job.yaml
+++ b/charts/she/templates/migration-job.yaml
@@ -21,6 +21,8 @@ spec:
       initContainers:
       - name: wait-for-postgres
         image: postgres:15-alpine
+        resources:
+          {{- toYaml .Values.enterprise.initContainers.resources | nindent 10 }}
         command:
           - /bin/sh
           - -c
@@ -34,7 +36,9 @@ spec:
       containers:
       - name: db-migration
         image: "{{ .Values.enterprise.image.repository }}:{{ .Values.enterprise.image.tag }}"
-        command: 
+        resources:
+          {{- toYaml .Values.enterprise.migration.resources | nindent 10 }}
+        command:
           - /bin/sh
           - -c
           - |

--- a/charts/she/templates/postgresql.yaml
+++ b/charts/she/templates/postgresql.yaml
@@ -22,6 +22,8 @@ spec:
       containers:
       - name: postgresql
         image: {{ .Values.enterprise.config.postgresql.image }}
+        resources:
+          {{- toYaml .Values.enterprise.config.postgresql.resources | nindent 10 }}
         env:
         - name: POSTGRES_DB
           value: {{ .Values.enterprise.config.postgresql.database }}

--- a/charts/she/values.yaml
+++ b/charts/she/values.yaml
@@ -236,11 +236,12 @@ service:
     backendHost: backend.example.com
     className: nginx # nginx, alb, traefik
     annotations:
+      # Example for NGINX Ingress:
       nginx.ingress.kubernetes.io/rewrite-target: /
-      # Example AWS ALB internal configuration
-     # alb.ingress.kubernetes.io/scheme: "internal"
-     # alb.ingress.kubernetes.io/security-groups: "sg-12345678"
-     # alb.ingress.kubernetes.io/certificate-arn: "arn:aws:acm:region:account-id:certificate/cert-id"
+      # Example AWS ALB internal configuration:
+      # alb.ingress.kubernetes.io/scheme: "internal"
+      # alb.ingress.kubernetes.io/security-groups: "sg-12345678"
+      # alb.ingress.kubernetes.io/certificate-arn: "arn:aws:acm:region:account-id:certificate/cert-id"
 
   annotations:  # put '{}' if you do not need service annotations
     example.com/dummy: ""

--- a/charts/she/values.yaml
+++ b/charts/she/values.yaml
@@ -10,6 +10,7 @@ enterprise:
     repository: hoppscotch/hoppscotch-enterprise
     tag: latest # Example: "v1.0.0"
     pullPolicy: IfNotPresent
+  # Main application resources (for deployment.yaml)
   resources:
     limits:
       cpu: 500m
@@ -17,8 +18,28 @@ enterprise:
     requests:
       cpu: 250m
       memory: 256Mi
+
+  # Init containers configuration (used by both deployment and migration job)
+  initContainers:
+    # Resources for init containers (wait-for-postgres, etc.)
+    resources:
+      limits:
+        cpu: 200m
+        memory: 256Mi
+      requests:
+        cpu: 100m
+        memory: 128Mi
+
   migration:
     upgradeEnabled: false # If true, the migration job will run on every helm upgrade
+    # Resources for the migration job container
+    resources:
+      limits:
+        cpu: 300m
+        memory: 256Mi
+      requests:
+        cpu: 150m
+        memory: 128Mi
 
   config:
     database:
@@ -31,6 +52,13 @@ enterprise:
       database: hoppscotchEnterprise
       username: hoppscotch
       password: hoppscotch123
+      resources:
+        requests:
+          cpu: "1"
+          memory: "1Gi"
+        limits:
+          cpu: "1"
+          memory: "2Gi"
 
     mailer:
       enable: false
@@ -207,15 +235,15 @@ service:
     adminHost: admin.example.com
     backendHost: backend.example.com
     className: nginx # nginx, alb, traefik
+    annotations:
+      nginx.ingress.kubernetes.io/rewrite-target: /
+      # Example AWS ALB internal configuration
+     # alb.ingress.kubernetes.io/scheme: "internal"
+     # alb.ingress.kubernetes.io/security-groups: "sg-12345678"
+     # alb.ingress.kubernetes.io/certificate-arn: "arn:aws:acm:region:account-id:certificate/cert-id"
 
-  annotations:
-    kubernetes.io/ingress.class: nginx
-    nginx.ingress.kubernetes.io/ssl-redirect: "false"
-    service.kubernetes.io/load-balancer-type: "External"
-    # Example AWS ALB internal configuration
-    # alb.ingress.kubernetes.io/scheme: "internal"
-    # alb.ingress.kubernetes.io/security-groups: "sg-12345678"
-    # alb.ingress.kubernetes.io/certificate-arn: "arn:aws:acm:region:account-id:certificate/cert-id"
+  annotations: {}   #remove {} if you want to use service annotations
+  #  service.kubernetes.io/load-balancer-type: "External"
 
   # TLS Configuration
   tls:

--- a/charts/she/values.yaml
+++ b/charts/she/values.yaml
@@ -243,9 +243,11 @@ service:
       # alb.ingress.kubernetes.io/security-groups: "sg-12345678"
       # alb.ingress.kubernetes.io/certificate-arn: "arn:aws:acm:region:account-id:certificate/cert-id"
 
-  annotations:  # put '{}' if you do not need service annotations
+  annotations:  # Define service annotations here if needed. For example, to configure a load balancer:
     example.com/dummy: ""
-  #  service.kubernetes.io/load-balancer-type: "External"
+    # service.kubernetes.io/load-balancer-type: "External"
+
+    # Remove the empty braces ({}) and add your annotations as key-value pairs.
 
   # TLS Configuration
   tls:

--- a/charts/she/values.yaml
+++ b/charts/she/values.yaml
@@ -13,33 +13,33 @@ enterprise:
   # Main application resources (for deployment.yaml)
   resources:
     limits:
-      cpu: 500m
-      memory: 512Mi
+      cpu: "500m"
+      memory: "512Mi"
     requests:
-      cpu: 250m
-      memory: 256Mi
+      cpu: "250m"
+      memory: "256Mi"
 
   # Init containers configuration (used by both deployment and migration job)
   initContainers:
     # Resources for init containers (wait-for-postgres, etc.)
     resources:
       limits:
-        cpu: 200m
-        memory: 256Mi
+        cpu: "200m"
+        memory: "256Mi"
       requests:
-        cpu: 100m
-        memory: 128Mi
+        cpu: "100m"
+        memory: "128Mi"
 
   migration:
     upgradeEnabled: false # If true, the migration job will run on every helm upgrade
     # Resources for the migration job container
     resources:
       limits:
-        cpu: 300m
-        memory: 256Mi
+        cpu: "300m"
+        memory: "256Mi"
       requests:
-        cpu: 150m
-        memory: 128Mi
+        cpu: "150m"
+        memory: "128Mi"
 
   config:
     database:
@@ -242,7 +242,8 @@ service:
      # alb.ingress.kubernetes.io/security-groups: "sg-12345678"
      # alb.ingress.kubernetes.io/certificate-arn: "arn:aws:acm:region:account-id:certificate/cert-id"
 
-  annotations: {}   #remove {} if you want to use service annotations
+  annotations:  # put '{}' if you do not need service annotations
+    example.com/dummy: ""
   #  service.kubernetes.io/load-balancer-type: "External"
 
   # TLS Configuration


### PR DESCRIPTION
Description
This PR add resource limits and request to init container and database migration Job main container as well as in the postgresql statefulset. And resource value can be changed from the values file.

Checks

- [x]  My pull request adheres to the code style of this project
- [ ]  My code requires changes to the documentation
- [ ]  I have updated the documentation as required
- [ ]  All the tests have passed