### PR TITLE
Feat: Add Google Authentication Configuration

### DIFF
--- a/charts/shc/templates/configmap.yaml
+++ b/charts/shc/templates/configmap.yaml
@@ -40,6 +40,10 @@ data:
   REDIRECT_URL: {{ .Values.community.config.urls.redirect | quote }}
   WHITELISTED_ORIGINS: {{ .Values.community.config.urls.whitelistedOrigins | quote }}
 
+  # Google Auth (non-sensitive)
+  GOOGLE_CALLBACK_URL: {{ .Values.community.config.auth.google.callbackUrl | quote }}
+  GOOGLE_SCOPE: {{ .Values.community.config.auth.google.scope | quote }}
+
   # community Config
   VITE_ALLOWED_AUTH_PROVIDERS: {{ .Values.community.config.auth.allowedProviders | quote }}
   ENABLE_SUBPATH_BASED_ACCESS: {{ .Values.community.config.community.enableSubpathBasedAccess | quote }}


### PR DESCRIPTION
**Description:**

This PR introduces new configuration parameters to the `charts/shc/templates/configmap.yaml` to support Google authentication.

Previously, users could not directly configure Google OAuth callback URLs and scopes via the Helm chart. This enhancement enables seamless integration with Google as an authentication provider by allowing these settings to be managed through the chart's `values.yaml` file.

**Changes Made:**

* Added `GOOGLE_CALLBACK_URL` and `GOOGLE_SCOPE` to the `community-config` ConfigMap in `charts/shc/templates/configmap.yaml`. These new fields are populated from `.Values.community.config.auth.google.callbackUrl` and `.Values.community.config.auth.google.scope` respectively.

**Why this enhancement would be useful:**

This enhancement provides greater flexibility and ease of deployment for users who wish to leverage Google authentication with Hoppscotch Community. It streamlines the configuration process by centralizing these settings within the Helm chart, aligning with standard Kubernetes deployment practices.

**How to Test:**

1.  Update your `values.yaml` to include the new Google authentication configuration under `community.config.auth.google`:
    ```yaml
    community:
      config:
        auth:
          google:
            callbackUrl: "YOUR_GOOGLE_CALLBACK_URL"
            scope: "email profile"
    ```
2.  Deploy the chart:
    ```bash
    helm upgrade --install hoppscotch-community ./charts/shc -f your-values.yaml
    ```
3.  Verify that the `GOOGLE_CALLBACK_URL` and `GOOGLE_SCOPE` environment variables are correctly populated in the deployed Hoppscotch Community pods by inspecting the `community-config` ConfigMap.
