### PR TITLE
Replace bitnami with alpine to use kubectl.

### DIFF
--- a/charts/shc/templates/deployment.yaml
+++ b/charts/shc/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
             done
       {{- end }}
       - name: wait-for-migration
-        image: bitnami/kubectl:latest
+        image: alpine/kubectl:latest
         command:
           - /bin/sh
           - -c

--- a/charts/she/templates/deployment.yaml
+++ b/charts/she/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
             done
       {{- end }}
       - name: wait-for-migration
-        image: bitnami/kubectl:latest
+        image: alpine/kubectl:latest
         resources:
           {{- toYaml .Values.enterprise.initContainers.resources | nindent 10 }}
         command:


### PR DESCRIPTION
As the announcement [here](https://github.com/bitnami/containers/issues/83267) bitnami is closing public repos, as of now the helm deployment of hoppscotch will not work since `kubectl` is not available anymore.

This PR will replace bitnami with alpine to fix the issue.