### PR TITLE
fix: Chart version validation has been added, and now we can manually…

### DIFF
--- a/.github/workflows/manual-chart-release.yaml
+++ b/.github/workflows/manual-chart-release.yaml
@@ -65,23 +65,48 @@ jobs:
           echo "App Version: ${{ github.event.inputs.app_version }}"
           echo "Release Type: ${{ github.event.inputs.release_type }}"
 
+          # Validate semantic versioning format
           if [[ ! "$CHART_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "ERROR: Invalid chart version format. Use semantic versioning (e.g., 0.2.0)"
             exit 1
           fi
 
+          # Check if chart exists
           if [ ! -f "charts/$CHART_NAME/Chart.yaml" ]; then
             echo "ERROR: Chart not found: charts/$CHART_NAME/Chart.yaml"
             exit 1
           fi
 
+          # Get current version and compare
           CURRENT_VERSION=$(yq eval '.version' "charts/$CHART_NAME/Chart.yaml")
           echo "Current chart version: $CURRENT_VERSION"
           echo "New chart version: $CHART_VERSION"
 
+          # Prevent same version release
           if [ "$CURRENT_VERSION" = "$CHART_VERSION" ]; then
-            echo "WARNING: New version is the same as current version"
+            echo "ERROR: New version must be different from current version"
+            echo "Current version in Chart.yaml: $CURRENT_VERSION"
+            echo "Requested version: $CHART_VERSION"
+            echo ""
+            echo "Please increment the version number before releasing."
+            exit 1
           fi
+
+          # Check if version is being incremented (not decremented)
+          IFS='.' read -ra CURR <<< "$CURRENT_VERSION"
+          IFS='.' read -ra NEW <<< "$CHART_VERSION"
+
+          CURRENT_NUM=$((CURR[0] * 10000 + CURR[1] * 100 + CURR[2]))
+          NEW_NUM=$((NEW[0] * 10000 + NEW[1] * 100 + NEW[2]))
+
+          if [ $NEW_NUM -le $CURRENT_NUM ]; then
+            echo "ERROR: New version ($CHART_VERSION) must be greater than current version ($CURRENT_VERSION)"
+            echo ""
+            echo "Semantic versioning requires incrementing version numbers."
+            exit 1
+          fi
+
+          echo "Version validation passed"
 
       - name: Update Chart.yaml
         run: |
@@ -202,6 +227,7 @@ jobs:
           echo ""
           echo "Common issues:"
           echo "  - Invalid version format (must be X.Y.Z)"
+          echo "  - Version not incremented properly"
           echo "  - Chart validation errors"
           echo "  - Git configuration issues"
           echo "  - Missing chart files"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - "charts/*/Chart.yaml"
+  workflow_dispatch:
 
 jobs:
   release:


### PR DESCRIPTION
**What Changes**
Chart version validation has been added, and now we can manually re-run the release if the release pipeline is broken due to an error.