### PR TITLE
fix: add toYaml for extraTls in ingress templates

### DIFF
--- a/charts/hoppscotch/templates/admin/ingress.yaml
+++ b/charts/hoppscotch/templates/admin/ingress.yaml
@@ -59,7 +59,7 @@ spec:
       secretName: {{ printf "%s-tls" .Values.admin.ingress.hostname }}
     {{- end }}
     {{- if .Values.admin.ingress.extraTls }}
-    {{- .Values.admin.ingress.extraTls | nindent 4 }}
+    {{- toYaml .Values.admin.ingress.extraTls | nindent 4 }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/hoppscotch/templates/aio/ingress.yaml
+++ b/charts/hoppscotch/templates/aio/ingress.yaml
@@ -59,7 +59,7 @@ spec:
       secretName: {{ printf "%s-tls" .Values.aio.ingress.hostname }}
     {{- end }}
     {{- if .Values.aio.ingress.extraTls }}
-    {{- .Values.aio.ingress.extraTls | nindent 4 }}
+    {{- toYaml .Values.aio.ingress.extraTls | nindent 4 }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/hoppscotch/templates/backend/ingress.yaml
+++ b/charts/hoppscotch/templates/backend/ingress.yaml
@@ -59,7 +59,7 @@ spec:
       secretName: {{ printf "%s-tls" .Values.backend.ingress.hostname }}
     {{- end }}
     {{- if .Values.backend.ingress.extraTls }}
-    {{- .Values.backend.ingress.extraTls | nindent 4 }}
+    {{- toYaml .Values.backend.ingress.extraTls | nindent 4 }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/hoppscotch/templates/frontend/ingress.yaml
+++ b/charts/hoppscotch/templates/frontend/ingress.yaml
@@ -59,7 +59,7 @@ spec:
       secretName: {{ printf "%s-tls" .Values.frontend.ingress.hostname }}
     {{- end }}
     {{- if .Values.frontend.ingress.extraTls }}
-    {{- .Values.frontend.ingress.extraTls | nindent 4 }}
+    {{- toYaml .Values.frontend.ingress.extraTls | nindent 4 }}
     {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
The extraTls field is an array but was being passed directly to nindnet, causing template rendering to fail.

This fix adds the toYaml function to properly convert the array to YAML before indenting, consistent with how extraRules and extraPaths are handled in the same templates.