### PR TITLE
feat(helm): add label customization option for service

### DIFF
--- a/charts/shc/templates/service.yaml
+++ b/charts/shc/templates/service.yaml
@@ -6,7 +6,9 @@ metadata:
   namespace: {{ .Values.global.namespace | default .Release.Namespace }}
   labels:
     app: {{ .Values.service.app }}
-    {{- toYaml .Values.service.labels | nindent 4 }}
+    {{- with .Values.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   annotations:
     {{- toYaml .Values.service.annotations | nindent 4 }}
 spec:

--- a/charts/shc/templates/service.yaml
+++ b/charts/shc/templates/service.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ .Values.global.namespace | default .Release.Namespace }}
   labels:
     app: {{ .Values.service.app }}
+    {{- toYaml .Values.service.labels | nindent 4 }}
   annotations:
     {{- toYaml .Values.service.annotations | nindent 4 }}
 spec:

--- a/charts/shc/values.yaml
+++ b/charts/shc/values.yaml
@@ -154,6 +154,9 @@ service:
     backendHost: backend.example.com
     className: nginx # nginx, alb, traefik
 
+  # labels:
+  #   custom-label: example
+
   annotations:
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/ssl-redirect: "false"


### PR DESCRIPTION
Currently it is not possible to set custom labels via the helm chart.

This PR adds that functionality.