### PR TITLE
feat(chart): add wildcard ingress support for mock server

### DIFF
--- a/charts/hoppscotch/README.md
+++ b/charts/hoppscotch/README.md
@@ -394,6 +394,129 @@ for the migrations job to complete.
 Instead the migration job is triggered by appending the release revision number to the job name to ensure that it is
 unique for each release. This allows the job to be run multiple times without conflicts.
 
+### Mock Server Wildcard Ingress
+
+Hoppscotch's mock server runs on the backend at `/mock/<mock-id>/<path>`. The mock server wildcard ingress feature
+enables subdomain-based access so that requests to `<mock-id>.mock.example.com/<path>` are transparently routed to the
+backend at `/mock/<mock-id>/<path>`.
+
+The mock server ingress is **independent of the deployment mode** — it works with both `aio` and `distributed` modes.
+It is disabled by default and has zero impact on existing deployments.
+
+#### Enabling Mock Server Ingress
+
+To enable the mock server wildcard ingress, set the following in your values file:
+
+```yaml
+mockServer:
+  ingress:
+    enabled: true
+    controllerType: nginx  # nginx | traefik | alb
+    hostname: mock.example.com
+    ingressClassName: nginx
+```
+
+This creates an Ingress resource with the wildcard host `*.mock.example.com` that routes all subdomain traffic to the
+Hoppscotch backend service.
+
+#### Supported Ingress Controllers
+
+The `controllerType` toggle selects the ingress controller and configures the appropriate annotations automatically.
+
+##### nginx
+
+When `controllerType: nginx`, the chart adds nginx-specific annotations that:
+
+1. Extract the `mock-id` from the subdomain using a server-snippet regex capture group
+2. Rewrite the request path to include the mock-id and the correct backend path prefix
+
+```yaml
+mockServer:
+  ingress:
+    enabled: true
+    controllerType: nginx
+    hostname: mock.example.com
+    ingressClassName: nginx
+```
+
+This is the recommended controller type as it provides full subdomain-to-path rewriting including mock-id extraction
+entirely at the ingress layer.
+
+##### traefik
+
+When `controllerType: traefik`, the chart creates an Ingress resource with a Traefik router middleware annotation and
+also creates a `Middleware` CRD (`traefik.io/v1alpha1`) that rewrites the request path.
+
+```yaml
+mockServer:
+  ingress:
+    enabled: true
+    controllerType: traefik
+    hostname: mock.example.com
+    ingressClassName: traefik
+```
+
+> **Note**: Traefik's `replacePathRegex` middleware can rewrite the request path but cannot extract the mock-id from
+> the Host header (subdomain). When using Traefik, the backend application must resolve the mock-id from the `Host`
+> header itself.
+
+##### alb (AWS Load Balancer)
+
+When `controllerType: alb`, the chart adds AWS ALB annotations for internet-facing load balancer configuration.
+
+```yaml
+mockServer:
+  ingress:
+    enabled: true
+    controllerType: alb
+    hostname: mock.example.com
+```
+
+> **Note**: AWS ALB does not support subdomain-to-path rewriting natively. When using ALB, the backend application
+> must resolve the mock-id from the `Host` header itself.
+
+#### Path Prefix Behavior
+
+The path prefix used for URL rewriting depends on the deployment mode and subpath access setting:
+
+| Deployment Mode | `enableSubpathBasedAccess` | Service Port | Path Prefix    |
+| --------------- | -------------------------- | ------------ | -------------- |
+| `aio`           | `true` (default)           | 80           | `/backend/mock` |
+| `aio`           | `false`                    | 3170         | `/mock`        |
+| `distributed`   | N/A                        | 80           | `/mock`        |
+
+#### TLS Configuration
+
+To enable TLS with a self-signed certificate:
+
+```yaml
+mockServer:
+  ingress:
+    enabled: true
+    controllerType: nginx
+    hostname: mock.example.com
+    ingressClassName: nginx
+    tls: true
+    selfSigned: true
+```
+
+To use an existing TLS secret (e.g., from cert-manager):
+
+```yaml
+mockServer:
+  ingress:
+    enabled: true
+    controllerType: nginx
+    hostname: mock.example.com
+    ingressClassName: nginx
+    tls: true
+    annotations:
+      cert-manager.io/cluster-issuer: letsencrypt-prod
+    tlsSecret: mock-example-com-wildcard-tls
+```
+
+The TLS secret covers the wildcard host `*.mock.example.com`.
+
 ## Parameters
 
 <!-- markdownlint-disable MD013 MD034 -->

--- a/charts/hoppscotch/README.md
+++ b/charts/hoppscotch/README.md
@@ -396,9 +396,9 @@ unique for each release. This allows the job to be run multiple times without co
 
 ### Mock Server Wildcard Ingress
 
-Hoppscotch's mock server runs on the backend at `/mock/<mock-id>/<path>`. The mock server wildcard ingress feature
-enables subdomain-based access so that requests to `<mock-id>.mock.example.com/<path>` are transparently routed to the
-backend at `/mock/<mock-id>/<path>`.
+Hoppscotch's mock server is served by the backend under `/mock/<mock-id>/<path>` (and via `/backend/mock/<mock-id>/<path>`
+when using AIO subpath access). The mock server wildcard ingress feature enables subdomain-based access so that requests
+to `<mock-id>.mock.example.com/<path>` are transparently routed to the appropriate backend path for your deployment mode.
 
 The mock server ingress is **independent of the deployment mode** — it works with both `aio` and `distributed` modes.
 It is disabled by default and has zero impact on existing deployments.
@@ -425,10 +425,17 @@ The `controllerType` toggle selects the ingress controller and configures the ap
 
 ##### nginx
 
-When `controllerType: nginx`, the chart adds nginx-specific annotations that:
+When `controllerType: nginx`, the chart adds nginx-specific annotations that (when snippet annotations are enabled on
+your nginx ingress controller):
 
 1. Extract the `mock-id` from the subdomain using a server-snippet regex capture group
 2. Rewrite the request path to include the mock-id and the correct backend path prefix
+
+> **Important**: The nginx option relies on `nginx.ingress.kubernetes.io/server-snippet` and
+> `nginx.ingress.kubernetes.io/configuration-snippet` annotations. Many ingress-nginx deployments disable snippet
+> annotations by default for security reasons (via `allow-snippet-annotations: "false"` in the controller config).
+> You must enable snippet annotations on your ingress-nginx controller for the mock-id extraction to work. Without
+> them, the rewrite will not function correctly.
 
 ```yaml
 mockServer:

--- a/charts/hoppscotch/README.md.gotmpl
+++ b/charts/hoppscotch/README.md.gotmpl
@@ -393,6 +393,137 @@ for the migrations job to complete.
 Instead the migration job is triggered by appending the release revision number to the job name to ensure that it is
 unique for each release. This allows the job to be run multiple times without conflicts.
 
+### Mock Server Wildcard Ingress
+
+Hoppscotch's mock server is served by the backend under `/mock/<mock-id>/<path>` (and via `/backend/mock/<mock-id>/<path>`
+when using AIO subpath access). The mock server wildcard ingress feature enables subdomain-based access so that requests
+to `<mock-id>.mock.example.com/<path>` are transparently routed to the appropriate backend path for your deployment mode.
+
+The mock server ingress is **independent of the deployment mode** — it works with both `aio` and `distributed` modes.
+It is disabled by default and has zero impact on existing deployments.
+
+#### Enabling Mock Server Ingress
+
+To enable the mock server wildcard ingress, set the following in your values file:
+
+```yaml
+mockServer:
+  ingress:
+    enabled: true
+    controllerType: nginx  # nginx | traefik | alb
+    hostname: mock.example.com
+    ingressClassName: nginx
+```
+
+This creates an Ingress resource with the wildcard host `*.mock.example.com` that routes all subdomain traffic to the
+Hoppscotch backend service.
+
+#### Supported Ingress Controllers
+
+The `controllerType` toggle selects the ingress controller and configures the appropriate annotations automatically.
+An unsupported value will cause the template to fail with a descriptive error message.
+
+##### nginx
+
+When `controllerType: nginx`, the chart adds nginx-specific annotations that (when snippet annotations are enabled on
+your nginx ingress controller):
+
+1. Extract the `mock-id` from the subdomain using a server-snippet regex capture group
+2. Rewrite the request path to include the mock-id and the correct backend path prefix
+
+> **Important**: The nginx option relies on `nginx.ingress.kubernetes.io/server-snippet` and
+> `nginx.ingress.kubernetes.io/configuration-snippet` annotations. Many ingress-nginx deployments disable snippet
+> annotations by default for security reasons (via `allow-snippet-annotations: "false"` in the controller config).
+> You must enable snippet annotations on your ingress-nginx controller for the mock-id extraction to work. Without
+> them, the rewrite will not function correctly.
+
+```yaml
+mockServer:
+  ingress:
+    enabled: true
+    controllerType: nginx
+    hostname: mock.example.com
+    ingressClassName: nginx
+```
+
+This is the recommended controller type as it provides full subdomain-to-path rewriting including mock-id extraction
+entirely at the ingress layer.
+
+##### traefik
+
+When `controllerType: traefik`, the chart creates an Ingress resource with a Traefik router middleware annotation and
+also creates a `Middleware` CRD (`traefik.io/v1alpha1`) that rewrites the request path.
+
+```yaml
+mockServer:
+  ingress:
+    enabled: true
+    controllerType: traefik
+    hostname: mock.example.com
+    ingressClassName: traefik
+```
+
+> **Note**: Traefik's `replacePathRegex` middleware can rewrite the request path but cannot extract the mock-id from
+> the Host header (subdomain). When using Traefik, the backend application must resolve the mock-id from the `Host`
+> header itself.
+
+##### alb (AWS Load Balancer)
+
+When `controllerType: alb`, the chart adds AWS ALB annotations for internet-facing load balancer configuration.
+
+```yaml
+mockServer:
+  ingress:
+    enabled: true
+    controllerType: alb
+    hostname: mock.example.com
+```
+
+> **Note**: AWS ALB does not support subdomain-to-path rewriting natively. When using ALB, the backend application
+> must resolve the mock-id from the `Host` header itself.
+
+#### Path Prefix Behavior
+
+The path prefix used for URL rewriting depends on the deployment mode and subpath access setting:
+
+| Deployment Mode | `enableSubpathBasedAccess` | Service Port | Path Prefix     |
+| --------------- | -------------------------- | ------------ | --------------- |
+| `aio`           | `true` (default)           | 80           | `/backend/mock` |
+| `aio`           | `false`                    | 3170         | `/mock`         |
+| `distributed`   | N/A                        | 80           | `/mock`         |
+
+#### TLS Configuration
+
+To enable TLS with a self-signed certificate:
+
+```yaml
+mockServer:
+  ingress:
+    enabled: true
+    controllerType: nginx
+    hostname: mock.example.com
+    ingressClassName: nginx
+    tls: true
+    selfSigned: true
+```
+
+To use an existing TLS secret (e.g., from cert-manager):
+
+```yaml
+mockServer:
+  ingress:
+    enabled: true
+    controllerType: nginx
+    hostname: mock.example.com
+    ingressClassName: nginx
+    tls: true
+    annotations:
+      cert-manager.io/cluster-issuer: letsencrypt-prod
+    tlsSecret: mock-example-com-wildcard-tls
+```
+
+The TLS secret covers the wildcard host `*.mock.example.com`.
+
 ## Parameters
 
 <!-- markdownlint-disable MD013 MD034 -->

--- a/charts/hoppscotch/ci/aio-mock-server-values.yaml
+++ b/charts/hoppscotch/ci/aio-mock-server-values.yaml
@@ -1,0 +1,24 @@
+deploymentMode: aio
+mockServer:
+  ingress:
+    enabled: true
+    controllerType: nginx
+    hostname: mock.hoppscotch.local
+    ingressClassName: nginx
+    tls: true
+    selfSigned: true
+aio:
+  readinessProbe:
+    initialDelaySeconds: 15
+  ingress:
+    enabled: true
+    hostname: hoppscotch.local
+postgresql:
+  enabled: true
+  auth:
+    username: hoppscotch
+    password: hoppscotch
+    database: hoppscotch
+  primary:
+    persistence:
+      enabled: false

--- a/charts/hoppscotch/templates/_helpers.tpl
+++ b/charts/hoppscotch/templates/_helpers.tpl
@@ -221,3 +221,47 @@ Return the service account name to use.
     {{- default "default" .Values.serviceAccount.name -}}
   {{- end -}}
 {{- end -}}
+
+{{/*
+Return the mock server service name based on deployment mode.
+In aio mode, the AIO service is used. In distributed mode, the backend service is used.
+*/}}
+{{- define "hoppscotch.mockServer.serviceName" -}}
+  {{- if eq .Values.deploymentMode "aio" -}}
+    {{- include "hoppscotch.aio.serviceName" . -}}
+  {{- else -}}
+    {{- include "hoppscotch.backend.serviceName" . -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Return the mock server service port based on deployment mode and subpath access setting.
+- aio + enableSubpathBasedAccess=true  → aio.service.ports.http (port 80, traffic via /backend/mock prefix)
+- aio + enableSubpathBasedAccess=false → aio.service.ports.backend (port 3170, direct backend port)
+- distributed                          → backend.service.ports.http (port 80)
+*/}}
+{{- define "hoppscotch.mockServer.servicePort" -}}
+  {{- if eq .Values.deploymentMode "aio" -}}
+    {{- if .Values.hoppscotch.frontend.enableSubpathBasedAccess -}}
+      {{- .Values.aio.service.ports.http -}}
+    {{- else -}}
+      {{- .Values.aio.service.ports.backend -}}
+    {{- end -}}
+  {{- else -}}
+    {{- .Values.backend.service.ports.http -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Return the mock server path prefix used for URL rewriting.
+- aio + enableSubpathBasedAccess=true  → /backend/mock (traffic goes through the subpath proxy)
+- aio + enableSubpathBasedAccess=false → /mock (direct backend access on port 3170)
+- distributed                          → /mock (direct backend access)
+*/}}
+{{- define "hoppscotch.mockServer.pathPrefix" -}}
+  {{- if and (eq .Values.deploymentMode "aio") .Values.hoppscotch.frontend.enableSubpathBasedAccess -}}
+    {{- "/backend/mock" -}}
+  {{- else -}}
+    {{- "/mock" -}}
+  {{- end -}}
+{{- end -}}

--- a/charts/hoppscotch/templates/mock-server/ingress.yaml
+++ b/charts/hoppscotch/templates/mock-server/ingress.yaml
@@ -74,9 +74,9 @@ spec:
     {{- if .Values.mockServer.ingress.extraRules }}
     {{- toYaml .Values.mockServer.ingress.extraRules | nindent 4 }}
     {{- end }}
-  {{- if or (and .Values.mockServer.ingress.tls (or (include "hoppscotch.hasCertManagerRequest" ( dict "annotations" .Values.mockServer.ingress.annotations )) .Values.mockServer.ingress.selfSigned)) .Values.mockServer.ingress.extraTls }}
+  {{- if or (and .Values.mockServer.ingress.tls (or (include "hoppscotch.hasCertManagerRequest" ( dict "annotations" .Values.mockServer.ingress.annotations )) (include "hoppscotch.hasCertManagerRequest" ( dict "annotations" .Values.commonAnnotations )) .Values.mockServer.ingress.selfSigned)) .Values.mockServer.ingress.extraTls }}
   tls:
-    {{- if and .Values.mockServer.ingress.tls (or (include "hoppscotch.hasCertManagerRequest" ( dict "annotations" .Values.mockServer.ingress.annotations )) .Values.mockServer.ingress.selfSigned) }}
+    {{- if and .Values.mockServer.ingress.tls (or (include "hoppscotch.hasCertManagerRequest" ( dict "annotations" .Values.mockServer.ingress.annotations )) (include "hoppscotch.hasCertManagerRequest" ( dict "annotations" .Values.commonAnnotations )) .Values.mockServer.ingress.selfSigned) }}
     - hosts:
         - {{ printf "*.%s" $hostname | quote }}
       secretName: {{ .Values.mockServer.ingress.tlsSecret | default (printf "%s-wildcard-tls" $hostname) }}

--- a/charts/hoppscotch/templates/mock-server/ingress.yaml
+++ b/charts/hoppscotch/templates/mock-server/ingress.yaml
@@ -1,0 +1,85 @@
+{{- if .Values.mockServer.ingress.enabled }}
+{{- $fullname := include "hoppscotch.fullname" . }}
+{{- $namespace := include "hoppscotch.namespace" . }}
+{{- $hostname := .Values.mockServer.ingress.hostname }}
+{{- $pathPrefix := include "hoppscotch.mockServer.pathPrefix" . }}
+{{- $serviceName := include "hoppscotch.mockServer.serviceName" . }}
+{{- $servicePort := include "hoppscotch.mockServer.servicePort" . | int }}
+{{- $controllerType := .Values.mockServer.ingress.controllerType }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullname }}-mock-server
+  namespace: {{ $namespace | quote }}
+  labels:
+    app.kubernetes.io/component: hoppscotch-mock-server
+    {{- include "hoppscotch.labels" . | nindent 4 }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- toYaml .Values.commonAnnotations | nindent 4 }}
+    {{- end }}
+    {{- if eq $controllerType "nginx" }}
+    {{/*
+    nginx: server-snippet extracts mock-id from the subdomain via a regex capture group.
+    configuration-snippet rewrites the path to include the mock-id and path prefix.
+    This provides full subdomain-to-path rewriting including mock-id extraction.
+    */}}
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/server-snippet: |
+      set $mock_id "";
+      if ($host ~ "^([^.]+)\.{{ $hostname | replace "." "\\." }}$") {
+        set $mock_id $1;
+      }
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      rewrite ^/(.*)$ {{ $pathPrefix }}/$mock_id/$1 break;
+    {{- else if eq $controllerType "traefik" }}
+    {{/*
+    traefik: references the Middleware CRD created in traefik-middleware.yaml.
+    NOTE: Traefik replacePathRegex cannot extract the subdomain from the Host header.
+    The backend application must resolve the mock-id from the Host header when using
+    traefik or alb ingress controllers.
+    */}}
+    traefik.ingress.kubernetes.io/router.middlewares: {{ $namespace }}-{{ $fullname }}-mock-rewrite@kubernetescrd
+    {{- else if eq $controllerType "alb" }}
+    {{/*
+    alb: sets scheme, target-type, and group name for AWS ALB.
+    NOTE: ALB does not support subdomain-to-path rewriting natively.
+    The backend application must resolve the mock-id from the Host header.
+    */}}
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/group.name: {{ $fullname }}-mock
+    {{- end }}
+    {{- if .Values.mockServer.ingress.annotations }}
+    {{- toYaml .Values.mockServer.ingress.annotations | nindent 4 }}
+    {{- end }}
+spec:
+  {{- if .Values.mockServer.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.mockServer.ingress.ingressClassName | quote }}
+  {{- end }}
+  rules:
+    - host: {{ printf "*.%s" $hostname | quote }}
+      http:
+        paths:
+          - path: {{ .Values.mockServer.ingress.path }}
+            pathType: {{ .Values.mockServer.ingress.pathType }}
+            backend:
+              service:
+                name: {{ $serviceName }}
+                port:
+                  number: {{ $servicePort }}
+    {{- if .Values.mockServer.ingress.extraRules }}
+    {{- toYaml .Values.mockServer.ingress.extraRules | nindent 4 }}
+    {{- end }}
+  {{- if or (and .Values.mockServer.ingress.tls (or (include "hoppscotch.hasCertManagerRequest" ( dict "annotations" .Values.mockServer.ingress.annotations )) .Values.mockServer.ingress.selfSigned)) .Values.mockServer.ingress.extraTls }}
+  tls:
+    {{- if and .Values.mockServer.ingress.tls (or (include "hoppscotch.hasCertManagerRequest" ( dict "annotations" .Values.mockServer.ingress.annotations )) .Values.mockServer.ingress.selfSigned) }}
+    - hosts:
+        - {{ printf "*.%s" $hostname | quote }}
+      secretName: {{ .Values.mockServer.ingress.tlsSecret | default (printf "%s-wildcard-tls" $hostname) }}
+    {{- end }}
+    {{- if .Values.mockServer.ingress.extraTls }}
+    {{- toYaml .Values.mockServer.ingress.extraTls | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/hoppscotch/templates/mock-server/ingress.yaml
+++ b/charts/hoppscotch/templates/mock-server/ingress.yaml
@@ -6,6 +6,9 @@
 {{- $serviceName := include "hoppscotch.mockServer.serviceName" . }}
 {{- $servicePort := include "hoppscotch.mockServer.servicePort" . | int }}
 {{- $controllerType := .Values.mockServer.ingress.controllerType }}
+{{- if not (has $controllerType (list "nginx" "traefik" "alb")) -}}
+{{- fail (printf "mockServer.ingress.controllerType must be one of nginx|traefik|alb, got %q" $controllerType) -}}
+{{- end -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/charts/hoppscotch/templates/mock-server/traefik-middleware.yaml
+++ b/charts/hoppscotch/templates/mock-server/traefik-middleware.yaml
@@ -1,0 +1,27 @@
+{{- if and .Values.mockServer.ingress.enabled (eq .Values.mockServer.ingress.controllerType "traefik") }}
+{{- $fullname := include "hoppscotch.fullname" . }}
+{{- $pathPrefix := include "hoppscotch.mockServer.pathPrefix" . }}
+{{/*
+NOTE: Traefik's replacePathRegex middleware can rewrite the request path but cannot extract
+the mock-id from the Host header (subdomain). When using traefik or alb as the ingress
+controller, the backend application must resolve the mock-id from the Host header itself.
+For full subdomain-to-path rewriting (including mock-id extraction), use nginx as the
+controllerType, which handles this via server-snippet and configuration-snippet annotations.
+*/}}
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: {{ $fullname }}-mock-rewrite
+  namespace: {{ include "hoppscotch.namespace" . | quote }}
+  labels:
+    app.kubernetes.io/component: hoppscotch-mock-server
+    {{- include "hoppscotch.labels" . | nindent 4 }}
+  {{- if .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml .Values.commonAnnotations | nindent 4 }}
+  {{- end }}
+spec:
+  replacePathRegex:
+    regex: "^/(.*)"
+    replacement: "{{ $pathPrefix }}/$1"
+{{- end }}

--- a/charts/hoppscotch/tests/mock_server_ingress_test.yaml
+++ b/charts/hoppscotch/tests/mock_server_ingress_test.yaml
@@ -251,6 +251,19 @@ tests:
           path: spec.ingressClassName
           value: nginx
 
+  - it: should fail when controllerType is invalid
+    template: mock-server/ingress.yaml
+    set:
+      deploymentMode: aio
+      mockServer:
+        ingress:
+          enabled: true
+          controllerType: invalid-controller
+          hostname: mock.hoppscotch.local
+    asserts:
+      - failedTemplate:
+          errorMessage: 'mockServer.ingress.controllerType must be one of nginx|traefik|alb, got "invalid-controller"'
+
   - it: should merge commonAnnotations with controller annotations
     template: mock-server/ingress.yaml
     set:

--- a/charts/hoppscotch/tests/mock_server_ingress_test.yaml
+++ b/charts/hoppscotch/tests/mock_server_ingress_test.yaml
@@ -251,6 +251,26 @@ tests:
           path: spec.ingressClassName
           value: nginx
 
+  - it: should render TLS block when cert-manager annotation is in commonAnnotations
+    template: mock-server/ingress.yaml
+    set:
+      deploymentMode: aio
+      commonAnnotations:
+        cert-manager.io/cluster-issuer: letsencrypt-prod
+      mockServer:
+        ingress:
+          enabled: true
+          controllerType: nginx
+          hostname: mock.hoppscotch.local
+          tls: true
+    asserts:
+      - equal:
+          path: spec.tls[0].hosts[0]
+          value: "*.mock.hoppscotch.local"
+      - equal:
+          path: spec.tls[0].secretName
+          value: mock.hoppscotch.local-wildcard-tls
+
   - it: should fail when controllerType is invalid
     template: mock-server/ingress.yaml
     set:

--- a/charts/hoppscotch/tests/mock_server_ingress_test.yaml
+++ b/charts/hoppscotch/tests/mock_server_ingress_test.yaml
@@ -1,0 +1,271 @@
+suite: Mock Server Ingress
+templates:
+  - mock-server/ingress.yaml
+  - mock-server/traefik-middleware.yaml
+  - config/configmap.yaml
+  - config/secret.yaml
+tests:
+  - it: should generate Ingress when enabled in aio mode
+    template: mock-server/ingress.yaml
+    set:
+      deploymentMode: aio
+      mockServer:
+        ingress:
+          enabled: true
+          hostname: mock.hoppscotch.local
+    asserts:
+      - containsDocument:
+          apiVersion: networking.k8s.io/v1
+          kind: Ingress
+      - equal:
+          path: metadata.name
+          value: release-name-hoppscotch-mock-server
+      - equal:
+          path: spec.rules[0].host
+          value: "*.mock.hoppscotch.local"
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: release-name-hoppscotch
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.port.number
+          value: 80
+
+  - it: should generate Ingress when enabled in distributed mode
+    template: mock-server/ingress.yaml
+    set:
+      deploymentMode: distributed
+      mockServer:
+        ingress:
+          enabled: true
+          hostname: mock.hoppscotch.local
+    asserts:
+      - containsDocument:
+          apiVersion: networking.k8s.io/v1
+          kind: Ingress
+      - equal:
+          path: metadata.name
+          value: release-name-hoppscotch-mock-server
+      - equal:
+          path: spec.rules[0].host
+          value: "*.mock.hoppscotch.local"
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: release-name-hoppscotch-backend
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.port.number
+          value: 80
+
+  - it: should not generate Ingress when disabled
+    template: mock-server/ingress.yaml
+    set:
+      mockServer:
+        ingress:
+          enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should include nginx annotations when controllerType is nginx
+    template: mock-server/ingress.yaml
+    set:
+      deploymentMode: aio
+      mockServer:
+        ingress:
+          enabled: true
+          controllerType: nginx
+          hostname: mock.hoppscotch.local
+    asserts:
+      - equal:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/use-regex"]
+          value: "true"
+      - matchRegex:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/server-snippet"]
+          pattern: "mock_id"
+      - matchRegex:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/configuration-snippet"]
+          pattern: "rewrite"
+
+  - it: should include traefik annotations when controllerType is traefik
+    template: mock-server/ingress.yaml
+    set:
+      deploymentMode: aio
+      mockServer:
+        ingress:
+          enabled: true
+          controllerType: traefik
+          hostname: mock.hoppscotch.local
+    asserts:
+      - matchRegex:
+          path: metadata.annotations["traefik.ingress.kubernetes.io/router.middlewares"]
+          pattern: "mock-rewrite@kubernetescrd"
+
+  - it: should include alb annotations when controllerType is alb
+    template: mock-server/ingress.yaml
+    set:
+      deploymentMode: aio
+      mockServer:
+        ingress:
+          enabled: true
+          controllerType: alb
+          hostname: mock.hoppscotch.local
+    asserts:
+      - equal:
+          path: metadata.annotations["alb.ingress.kubernetes.io/scheme"]
+          value: internet-facing
+      - equal:
+          path: metadata.annotations["alb.ingress.kubernetes.io/target-type"]
+          value: ip
+      - matchRegex:
+          path: metadata.annotations["alb.ingress.kubernetes.io/group.name"]
+          pattern: "mock$"
+
+  - it: should include TLS block with wildcard host when tls is true and selfSigned is true
+    template: mock-server/ingress.yaml
+    set:
+      deploymentMode: aio
+      mockServer:
+        ingress:
+          enabled: true
+          hostname: mock.hoppscotch.local
+          tls: true
+          selfSigned: true
+    asserts:
+      - equal:
+          path: spec.tls[0].hosts[0]
+          value: "*.mock.hoppscotch.local"
+      - equal:
+          path: spec.tls[0].secretName
+          value: mock.hoppscotch.local-wildcard-tls
+
+  - it: should use custom tlsSecret when provided
+    template: mock-server/ingress.yaml
+    set:
+      deploymentMode: aio
+      mockServer:
+        ingress:
+          enabled: true
+          hostname: mock.hoppscotch.local
+          tls: true
+          selfSigned: true
+          tlsSecret: my-custom-wildcard-tls
+    asserts:
+      - equal:
+          path: spec.tls[0].secretName
+          value: my-custom-wildcard-tls
+
+  - it: should use aio backend port (3170) when enableSubpathBasedAccess is false
+    template: mock-server/ingress.yaml
+    set:
+      deploymentMode: aio
+      hoppscotch:
+        frontend:
+          enableSubpathBasedAccess: false
+      mockServer:
+        ingress:
+          enabled: true
+          hostname: mock.hoppscotch.local
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.port.number
+          value: 3170
+
+  - it: should create Traefik Middleware when controllerType is traefik
+    template: mock-server/traefik-middleware.yaml
+    set:
+      deploymentMode: aio
+      mockServer:
+        ingress:
+          enabled: true
+          controllerType: traefik
+          hostname: mock.hoppscotch.local
+    asserts:
+      - containsDocument:
+          apiVersion: traefik.io/v1alpha1
+          kind: Middleware
+      - equal:
+          path: metadata.name
+          value: release-name-hoppscotch-mock-rewrite
+      - equal:
+          path: spec.replacePathRegex.regex
+          value: "^/(.*)"
+      - matchRegex:
+          path: spec.replacePathRegex.replacement
+          pattern: "^/backend/mock/\\$1$"
+
+  - it: should create Traefik Middleware with /mock prefix when enableSubpathBasedAccess is false
+    template: mock-server/traefik-middleware.yaml
+    set:
+      deploymentMode: aio
+      hoppscotch:
+        frontend:
+          enableSubpathBasedAccess: false
+      mockServer:
+        ingress:
+          enabled: true
+          controllerType: traefik
+          hostname: mock.hoppscotch.local
+    asserts:
+      - containsDocument:
+          apiVersion: traefik.io/v1alpha1
+          kind: Middleware
+      - matchRegex:
+          path: spec.replacePathRegex.replacement
+          pattern: "^/mock/\\$1$"
+
+  - it: should not create Traefik Middleware when controllerType is nginx
+    template: mock-server/traefik-middleware.yaml
+    set:
+      deploymentMode: aio
+      mockServer:
+        ingress:
+          enabled: true
+          controllerType: nginx
+          hostname: mock.hoppscotch.local
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not create Traefik Middleware when ingress is disabled
+    template: mock-server/traefik-middleware.yaml
+    set:
+      deploymentMode: aio
+      mockServer:
+        ingress:
+          enabled: false
+          controllerType: traefik
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should set ingressClassName when provided
+    template: mock-server/ingress.yaml
+    set:
+      deploymentMode: aio
+      mockServer:
+        ingress:
+          enabled: true
+          hostname: mock.hoppscotch.local
+          ingressClassName: nginx
+    asserts:
+      - equal:
+          path: spec.ingressClassName
+          value: nginx
+
+  - it: should merge commonAnnotations with controller annotations
+    template: mock-server/ingress.yaml
+    set:
+      deploymentMode: aio
+      commonAnnotations:
+        custom.annotation/key: custom-value
+      mockServer:
+        ingress:
+          enabled: true
+          controllerType: nginx
+          hostname: mock.hoppscotch.local
+    asserts:
+      - equal:
+          path: metadata.annotations["custom.annotation/key"]
+          value: custom-value
+      - equal:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/use-regex"]
+          value: "true"

--- a/charts/hoppscotch/values.yaml
+++ b/charts/hoppscotch/values.yaml
@@ -1783,6 +1783,47 @@ defaultInitContainers:
     # @section -- Default Init Containers Parameters
     extraEnvVarsSecret: ""
 
+# @section -- Mock Server Parameters
+
+mockServer:
+  ingress:
+    # -- Enable wildcard ingress for the mock server
+    # @section -- Mock Server Parameters
+    enabled: false
+    # -- Ingress controller type (nginx, traefik, or alb)
+    # @section -- Mock Server Parameters
+    controllerType: nginx
+    # -- Ingress class name
+    # @section -- Mock Server Parameters
+    ingressClassName: ""
+    # -- Wildcard hostname for mock server ingress (wildcard will be *.<hostname>)
+    # @section -- Mock Server Parameters
+    hostname: mock.hoppscotch.local
+    # -- Ingress path
+    # @section -- Mock Server Parameters
+    path: /
+    # -- Ingress path type
+    # @section -- Mock Server Parameters
+    pathType: ImplementationSpecific
+    # -- Additional annotations for the mock server ingress
+    # @section -- Mock Server Parameters
+    annotations: {}
+    # -- Enable TLS for mock server ingress
+    # @section -- Mock Server Parameters
+    tls: false
+    # -- Create self-signed TLS certificates for mock server ingress
+    # @section -- Mock Server Parameters
+    selfSigned: false
+    # -- Existing TLS secret name for mock server ingress (auto-generated if empty)
+    # @section -- Mock Server Parameters
+    tlsSecret: ""
+    # -- Extra TLS configurations for mock server ingress
+    # @section -- Mock Server Parameters
+    extraTls: []
+    # -- Extra ingress rules for mock server ingress
+    # @section -- Mock Server Parameters
+    extraRules: []
+
 # @section -- Other Parameters
 
 serviceAccount:


### PR DESCRIPTION

##  Summary 
Wildcard subdomain ingress for the mock server so users can hit `<mock-id>.mock.example.com/path` instead of wiring up routes to `backend:3170/mock/<mock-id>/path` manually.

## Changes

- New `mockServer.ingress` section in values.yaml (off by default, no impact on existing installs)
- New ingress template + helpers that auto-resolve the right service/port for both aio and distributed modes
- Supports nginx, traefik, and ALB via a `controllerType` toggle
- Traefik middleware CRD for path rewriting (only created when using traefik)
- Helm unit tests + CI values

## Goal

- Wildcard DNS: `*.mock.example.com` → User ingress controller
- Wildcard TLS cert if using HTTPS (cert-manager DNS01 works)

## Testing

- helm lint ✓
- helm template renders correctly for all 3 controllers
- unit tests pass for aio + distributed modes