### PR TITLE
feat(hoppscotch): add OpenShift compatibility and Route support

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,167 @@
+# Migrating from `shc` / `she` to the unified `hoppscotch` chart
+
+The `hoppscotch` chart supersedes the separate `shc` (Community) and `she` (Enterprise)
+charts. This guide describes how to move an existing deployment across **without losing
+data**.
+
+> `shc` and `she` remain published and are maintained for backward compatibility. There is
+> no forced end-of-life — migrate when it suits you.
+
+## Why this is not an in-place `helm upgrade`
+
+The chart name, resource names, labels, and values schema all differ between `shc`/`she`
+and `hoppscotch`, so `helm upgrade` cannot transform one release into the other. The
+migration is instead a **parallel install that reuses your existing database**, followed by
+a traffic cutover. Your data lives in PostgreSQL, so preserving the database (and the
+encryption/JWT secrets) is what preserves the data.
+
+## The single most important rule
+
+Carry these three values over **unchanged**:
+
+- `dataEncryptionKey`
+- `jwtSecret`
+- `sessionSecret`
+
+They are not row data, but the application uses them to encrypt sensitive fields in the
+database and to sign sessions. If they change, previously encrypted values become
+unreadable and every user session is invalidated. Copy them verbatim from the old release.
+
+## Prerequisites
+
+- A maintenance window (brief downtime at cutover).
+- A backup of the database and, for Enterprise, the ClickHouse audit data if retained.
+- The old release's values: `helm get values <old-release> -n <namespace> > old-values.yaml`.
+
+Redis (Enterprise) holds only ephemeral session/scaling state and does not need migrating.
+
+## Migration flow
+
+1. **Back up and freeze.**
+
+   ```bash
+   pg_dump "<existing-connection-string>" > hoppscotch-backup.sql
+   ```
+
+2. **Extract the secrets to carry over** from `old-values.yaml`
+   (`config.authjwt.dataEncryptionKey`, `config.authjwt.jwtSecret`,
+   `config.authjwt.sessionSecret`).
+
+3. **Point the new chart at the same database.** Reusing the existing database in place is
+   the simplest and safest option:
+
+   ```yaml
+   postgresql:
+     enabled: false
+   externalDatabase:
+     sqlConnection: "<existing-connection-string>"
+   ```
+
+   Alternatively, restore `hoppscotch-backup.sql` into a fresh or bundled PostgreSQL and
+   point `externalDatabase` / `postgresql` at that.
+
+4. **Translate the values** using the [mapping](#values-mapping) below. Pay attention to the
+   [format changes](#format-changes-that-silently-break-things).
+
+5. **Install `hoppscotch` as a new, parallel release with routing disabled** so the old
+   release keeps serving traffic:
+
+   ```bash
+   helm upgrade --install hoppscotch hoppscotch/hoppscotch \
+     -n <namespace> -f new-values.yaml \
+     --set aio.ingress.enabled=false --set aio.route.enabled=false
+   ```
+
+   The migrations Job runs `prisma migrate deploy`, which is idempotent and upgrades the
+   schema on top of your existing data.
+
+6. **Validate against the same data** (via a temporary host or `kubectl port-forward`):
+   - Logging in works → the secrets were carried over correctly.
+   - Existing workspaces, collections and history are present → the database was reused
+     correctly.
+
+7. **Cut over.** Point your hostname / Ingress / Route at the new release
+   (`aio.ingress.enabled=true` or `aio.route.enabled=true`) and verify end to end.
+
+8. **Decommission** the old release once you are confident — but only after confirming its
+   PVCs are not the database you are still using:
+
+   ```bash
+   helm uninstall <old-release> -n <namespace>
+   ```
+
+## Rollback
+
+Because the old release stays running until cutover, rollback is simply re-pointing traffic
+back to it. Keep the old release and its PVCs for a few days after cutover.
+
+## Values mapping
+
+| `shc` / `she` (old)                                   | `hoppscotch` (new)                                                       | Notes |
+| ----------------------------------------------------- | ------------------------------------------------------------------------ | ----- |
+| `global.namespace`                                    | `-n <ns>` / `namespaceOverride`                                          | |
+| `community`/`enterprise.replicas`                     | `aio.replicaCount` (or per-component `replicaCount`)                     | |
+| `community`/`enterprise.image.*`                      | `aio.image.*` (or `frontend`/`backend`/`admin.image.*`)                  | |
+| `config.database.external` / `config.database.url`    | `externalDatabase.sqlConnection` (or `postgresql.enabled`)              | |
+| `config.postgresql.*`                                 | `postgresql.auth.*` + `postgresql.primary.persistence.*`                | Bitnami subchart |
+| `config.authjwt.dataEncryptionKey`                    | `hoppscotch.backend.dataEncryptionKey`                                   | **carry over** |
+| `config.authjwt.jwtSecret`                            | `hoppscotch.backend.authToken.jwtSecret`                                 | **carry over** |
+| `config.authjwt.sessionSecret`                        | `hoppscotch.backend.authToken.sessionSecret`                            | **carry over** |
+| `config.authjwt.tokenSaltComplexity`                  | `hoppscotch.backend.authToken.tokenSaltComplexity`                      | |
+| `config.authjwt.magicLinkTokenValidity`              | `hoppscotch.backend.authToken.magicLinkTokenValidity`                  | days |
+| `config.authjwt.refreshTokenValidity`                 | `hoppscotch.backend.authToken.refreshTokenValidity`                    | convert to **ms** |
+| `config.authjwt.accessTokenValidity`                  | `hoppscotch.backend.authToken.accessTokenValidity`                     | convert to **ms** |
+| `config.urls.base`                                    | `hoppscotch.frontend.baseUrl`                                            | |
+| `config.urls.shortcode`                               | `hoppscotch.frontend.shortcodeBaseUrl`                                   | |
+| `config.urls.admin`                                   | `hoppscotch.frontend.adminUrl`                                           | |
+| `config.urls.backend.gql` / `.ws` / `.api`            | `hoppscotch.frontend.backendGqlUrl` / `backendWsUrl` / `backendApiUrl`  | |
+| `config.urls.redirect`                                | `hoppscotch.backend.redirectUrl`                                         | |
+| `config.urls.whitelistedOrigins` (CSV)                | `hoppscotch.backend.whitelistedOrigins` (YAML list)                    | split CSV → list |
+| `config.auth.allowedProviders` (e.g. `GOOGLE,EMAIL`)  | `hoppscotch.backend.auth.allowedProviders` (e.g. `[google, email]`)    | lowercase list |
+| `config.auth.google.*`                                | `hoppscotch.backend.auth.google.*`                                      | `scope` CSV → list |
+| `config.auth.github.*`                                | `hoppscotch.backend.auth.github.*` (+ `githubEnterprise.*`)            | |
+| `config.auth.microsoft.*`                             | `hoppscotch.backend.auth.microsoft.*`                                   | |
+| `config.auth.oidc.*` (Enterprise)                     | `hoppscotch.backend.auth.oidc.*`                                        | |
+| `config.auth.saml.*` (Enterprise)                     | `hoppscotch.backend.auth.saml.*`                                        | |
+| `config.mailer.enable`                                | `hoppscotch.backend.mailer.smtpEnabled`                                 | |
+| `config.mailer.smtp.*`                                | `hoppscotch.backend.mailer.smtpUrl` / `smtpHost` / `smtpPort` / …       | |
+| `config.rateLimit.*`                                  | `hoppscotch.backend.rateLimit.*`                                        | |
+| `config.community/enterprise.enableSubpathBasedAccess`| `hoppscotch.frontend.enableSubpathBasedAccess`                         | |
+| `config.enterprise.licenseKey` (Enterprise)           | `hoppscotch.backend.enterpriseLicenseKey`                              | |
+| `config.horizontalScaling.enabled` (Enterprise)       | `hoppscotch.backend.horizontalScalingEnabled` (+ `autoscaling.*`)      | |
+| `config.redis.*` (Enterprise)                         | `redis.*` (Bitnami) or `externalRedis.*`                               | |
+| `config.clickhouse.*` (Enterprise)                    | `clickhouse.*` / `externalClickhouse.*`; `allowAuditLogs` → `hoppscotch.backend.allowAuditLogs` | |
+| `config.links.tos` / `config.links.privacyPolicy`     | `hoppscotch.frontend.appTosLink` / `appPrivacyPolicyLink`              | |
+| `service.ingress.{mainHost,adminHost,backendHost,className}` | `aio.ingress.*` (or per-component `ingress.*`)                  | |
+| `service.tls.*`                                       | `aio.ingress.tls` / `extraTls`                                          | |
+| `serviceAccount.*`                                    | `serviceAccount.*`                                                      | |
+
+## Format changes that silently break things
+
+These change shape between the charts and will not error — they just misbehave if missed:
+
+- **Token validity** is now in **milliseconds**, not duration strings. `"1d"` → `"86400000"`,
+  one week → `"604800000"`.
+- **`allowedProviders`** is a **lowercase YAML list**, not an uppercase CSV string:
+  `"GOOGLE,EMAIL"` → `[google, email]`.
+- **`whitelistedOrigins`** is a **YAML list**, not a comma-separated string.
+- OAuth **`scope`** fields are lists, not CSV strings.
+
+## Deployment mode
+
+`shc`/`she` run the all-in-one image, so the closest equivalent is `deploymentMode: aio`
+with `hoppscotch.frontend.enableSubpathBasedAccess` matching your old
+`enableSubpathBasedAccess`. Switching to `deploymentMode: distributed` (separate
+frontend/backend/admin) is a good opportunity for higher availability, but is optional and
+independent of the data migration.
+
+## Validation checklist
+
+- [ ] Database backed up before starting.
+- [ ] `dataEncryptionKey`, `jwtSecret`, `sessionSecret` copied verbatim.
+- [ ] New release points at the existing database (or a restored copy).
+- [ ] Token validity converted to milliseconds; `allowedProviders` / `whitelistedOrigins` /
+      `scope` converted to lists.
+- [ ] Migrations Job `Completed`.
+- [ ] Login works and existing collections/workspaces are visible.
+- [ ] Traffic cut over; old release kept running until verified.

--- a/README.md
+++ b/README.md
@@ -44,19 +44,31 @@
 
 🔄 **High Availability:** Built-in redundancy and failover capabilities.
 
+### **Available Charts**
+
+| Chart | Description |
+| ----- | ----------- |
+| [`hoppscotch`](charts/hoppscotch) | **Recommended.** Unified chart (Community + Enterprise, AIO or distributed) — used by the guides below |
+| [`shc`](charts/shc) | Community edition chart — maintained for backward compatibility, superseded by [`hoppscotch`](charts/hoppscotch) |
+| [`she`](charts/she) | Enterprise edition chart — maintained for backward compatibility, superseded by [`hoppscotch`](charts/hoppscotch) |
+
+> For deployment modes, configuration and the full parameters list, see the **[chart README](charts/hoppscotch/README.md)** — it is the authoritative install guide. The guides below are provider-specific quick starts.
+>
+> Migrating an existing `shc` or `she` deployment? Follow the **[migration guide](MIGRATION.md)**.
+
 ### **Installation Guides**
 
 <details>
 <summary><b>Digital Ocean Installation</b></summary>
 
-## Prerequisites
+**Prerequisites**
 
-- Digital Ocean account with administrative access
-- kubectl CLI tool
-- Helm 3.x installed
-- doctl installed
+- Access to a DOKS cluster (kubeconfig via `doctl` or the console)
+- Cluster permissions to create the chart's resources (cluster-admin only if you also install an ingress controller)
+- kubectl and Helm 3.x
+- doctl (to fetch the kubeconfig)
 
-## Quick Install
+**Quick Install**
 
 ```bash
 # Configure access
@@ -68,27 +80,27 @@ kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/cont
 # Add chart repository
 helm repo add hoppscotch https://hoppscotch.github.io/helm-charts
 
-# Deploy application
-## Community
-helm install [RELEASE_NAME] hoppscotch/hoppscotch-community -f [path-to-values-file]
-
-## Enterprise
-helm install [RELEASE_NAME] hoppscotch/hoppscotch-enterprise -f [path-to-values-file]
+# Deploy application (edition is selected in your values file)
+helm install [RELEASE_NAME] hoppscotch/hoppscotch -f [path-to-values-file]
 ```
+
+> Configuration (deployment mode, database, ingress/TLS, etc.) is set in your values file — see the [chart README](charts/hoppscotch/README.md) for the full guide and all parameters.
+>
+> - **Load balancer / ingress:** use NGINX ingress (`aio.ingress.*`) or a DigitalOcean LB via `aio.service.type: LoadBalancer` with `service.beta.kubernetes.io/do-loadbalancer-*` under `aio.service.annotations`. In `distributed` mode the same keys exist per component.
 
 </details>
 
 <details>
 <summary><b>GCP Installation</b></summary>
 
-## Prerequisites
+**Prerequisites**
 
-- Google Cloud account with GKE access
-- gcloud CLI configured
-- kubectl CLI tool
-- Helm 3.x installed
+- Access to a GKE cluster (kubeconfig via `gcloud`)
+- Cluster permissions to create the chart's resources (cluster-admin only if you also install an ingress controller)
+- kubectl and Helm 3.x
+- gcloud CLI (to fetch the kubeconfig)
 
-## Quick Install
+**Quick Install**
 
 ```bash
 # Configure cluster access
@@ -100,13 +112,105 @@ kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/cont
 # Add chart repository
 helm repo add hoppscotch https://hoppscotch.github.io/helm-charts
 
-# Deploy application
-## Community
-helm install [RELEASE_NAME] hoppscotch/hoppscotch-community -f [path-to-values-file]
-
-## Enterprise
-helm install [RELEASE_NAME] hoppscotch/hoppscotch-enterprise -f [path-to-values-file]
+# Deploy application (edition is selected in your values file)
+helm install [RELEASE_NAME] hoppscotch/hoppscotch -f [path-to-values-file]
 ```
+
+> Configuration (deployment mode, database, ingress/TLS, etc.) is set in your values file — see the [chart README](charts/hoppscotch/README.md) for the full guide and all parameters.
+>
+> - **Load balancer / ingress:** use the GKE ingress (`aio.ingress.ingressClassName: gce` + `aio.ingress.annotations`) or a Google Cloud LB via `aio.service.type: LoadBalancer` with `networking.gke.io/*` under `aio.service.annotations`. In `distributed` mode the same keys exist per component.
+
+</details>
+
+<details>
+<summary><b>AWS EKS Installation</b></summary>
+
+**Prerequisites**
+
+- Access to an EKS cluster (kubeconfig via `aws eks update-kubeconfig`)
+- Cluster permissions to create the chart's resources (cluster-admin only if you also install an ingress/ALB controller)
+- kubectl and Helm 3.x
+- AWS CLI (to fetch the kubeconfig)
+
+**Quick Install**
+
+```bash
+# Configure cluster access
+aws eks update-kubeconfig --name cluster-name --region region
+
+# (Optional) Install NGINX Ingress
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.8.2/deploy/static/provider/aws/deploy.yaml
+
+# Add chart repository
+helm repo add hoppscotch https://hoppscotch.github.io/helm-charts
+
+# Deploy application (edition is selected in your values file)
+helm install [RELEASE_NAME] hoppscotch/hoppscotch -f [path-to-values-file]
+```
+
+> Configuration (deployment mode, database, ingress/TLS, etc.) is set in your values file — see the [chart README](charts/hoppscotch/README.md) for the full guide and all parameters.
+>
+> - **Load balancer / ingress:** use an ALB (`aio.ingress.ingressClassName: alb` + `alb.ingress.kubernetes.io/*`, AWS Load Balancer Controller required) or an NLB via `aio.service.type: LoadBalancer` with `service.beta.kubernetes.io/aws-load-balancer-*` under `aio.service.annotations`. In `distributed` mode the same keys exist per component.
+
+</details>
+
+<details>
+<summary><b>Azure AKS Installation</b></summary>
+
+**Prerequisites**
+
+- Access to an AKS cluster (kubeconfig via `az aks get-credentials`)
+- Cluster permissions to create the chart's resources (cluster-admin only if you also install an ingress controller)
+- kubectl and Helm 3.x
+- Azure CLI (to fetch the kubeconfig)
+
+**Quick Install**
+
+```bash
+# Configure cluster access
+az aks get-credentials --resource-group resource-group --name cluster-name
+
+# (Optional) Install NGINX Ingress
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.8.2/deploy/static/provider/cloud/deploy.yaml
+
+# Add chart repository
+helm repo add hoppscotch https://hoppscotch.github.io/helm-charts
+
+# Deploy application (edition is selected in your values file)
+helm install [RELEASE_NAME] hoppscotch/hoppscotch -f [path-to-values-file]
+```
+
+> Configuration (deployment mode, database, ingress/TLS, etc.) is set in your values file — see the [chart README](charts/hoppscotch/README.md) for the full guide and all parameters.
+>
+> - **Load balancer / ingress:** use Application Gateway ingress (`aio.ingress.ingressClassName: azure-application-gateway` + `appgw.ingress.kubernetes.io/*`) or an Azure LB via `aio.service.type: LoadBalancer` with `service.beta.kubernetes.io/azure-load-balancer-*` under `aio.service.annotations`. In `distributed` mode the same keys exist per component.
+
+</details>
+
+<details>
+<summary><b>OpenShift Installation</b></summary>
+
+**Prerequisites**
+
+- OpenShift 4.x cluster (works on the default `restricted-v2` SCC — no cluster-admin required)
+- oc CLI logged in to your cluster
+- Helm 3.x installed
+
+**Quick Install**
+
+```bash
+# Add chart repository
+helm repo add hoppscotch https://hoppscotch.github.io/helm-charts
+
+# Deploy on OpenShift (adapts securityContext for restricted-v2 and exposes a Route)
+helm upgrade --install [RELEASE_NAME] hoppscotch/hoppscotch \
+  --namespace hoppscotch --create-namespace \
+  -f [path-to-values-file]
+```
+
+On OpenShift, enable `global.compatibility.openshift.adaptSecurityContext` and expose the app with a Route
+instead of an Ingress. See the chart's [Deploying on OpenShift](charts/hoppscotch/README.md#deploying-on-openshift)
+guide for the full walkthrough — `restricted-v2` requirements, `HOPP_ALTERNATE_PORT`, and both `aio` and
+`distributed` modes.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@
 
 | Chart | Description |
 | ----- | ----------- |
-| [`hoppscotch`](charts/hoppscotch) | **Recommended.** Unified chart (Community + Enterprise, AIO or distributed) — used by the guides below |
-| [`shc`](charts/shc) | Community edition chart — maintained for backward compatibility, superseded by [`hoppscotch`](charts/hoppscotch) |
-| [`she`](charts/she) | Enterprise edition chart — maintained for backward compatibility, superseded by [`hoppscotch`](charts/hoppscotch) |
+| [`hoppscotch`](charts/hoppscotch) | **Recommended.** Unified chart (Community + Enterprise, AIO or distributed); used by the guides below |
+| [`shc`](charts/shc) | Community edition chart, maintained for backward compatibility, superseded by [`hoppscotch`](charts/hoppscotch) |
+| [`she`](charts/she) | Enterprise edition chart, maintained for backward compatibility, superseded by [`hoppscotch`](charts/hoppscotch) |
 
-> For deployment modes, configuration and the full parameters list, see the **[chart README](charts/hoppscotch/README.md)** — it is the authoritative install guide. The guides below are provider-specific quick starts.
+> For deployment modes, configuration and the full parameters list, see the **[chart README](charts/hoppscotch/README.md)** . It is the authoritative install guide. The guides below are provider-specific quick starts.
 >
 > Migrating an existing `shc` or `she` deployment? Follow the **[migration guide](MIGRATION.md)**.
 
@@ -84,7 +84,7 @@ helm repo add hoppscotch https://hoppscotch.github.io/helm-charts
 helm install [RELEASE_NAME] hoppscotch/hoppscotch -f [path-to-values-file]
 ```
 
-> Configuration (deployment mode, database, ingress/TLS, etc.) is set in your values file — see the [chart README](charts/hoppscotch/README.md) for the full guide and all parameters.
+> Configuration (deployment mode, database, ingress/TLS, etc.) is set in your values file. See the [chart README](charts/hoppscotch/README.md) for the full guide and all parameters.
 >
 > - **Load balancer / ingress:** use NGINX ingress (`aio.ingress.*`) or a DigitalOcean LB via `aio.service.type: LoadBalancer` with `service.beta.kubernetes.io/do-loadbalancer-*` under `aio.service.annotations`. In `distributed` mode the same keys exist per component.
 
@@ -116,7 +116,7 @@ helm repo add hoppscotch https://hoppscotch.github.io/helm-charts
 helm install [RELEASE_NAME] hoppscotch/hoppscotch -f [path-to-values-file]
 ```
 
-> Configuration (deployment mode, database, ingress/TLS, etc.) is set in your values file — see the [chart README](charts/hoppscotch/README.md) for the full guide and all parameters.
+> Configuration (deployment mode, database, ingress/TLS, etc.) is set in your values file. See the [chart README](charts/hoppscotch/README.md) for the full guide and all parameters.
 >
 > - **Load balancer / ingress:** use the GKE ingress (`aio.ingress.ingressClassName: gce` + `aio.ingress.annotations`) or a Google Cloud LB via `aio.service.type: LoadBalancer` with `networking.gke.io/*` under `aio.service.annotations`. In `distributed` mode the same keys exist per component.
 
@@ -148,7 +148,7 @@ helm repo add hoppscotch https://hoppscotch.github.io/helm-charts
 helm install [RELEASE_NAME] hoppscotch/hoppscotch -f [path-to-values-file]
 ```
 
-> Configuration (deployment mode, database, ingress/TLS, etc.) is set in your values file — see the [chart README](charts/hoppscotch/README.md) for the full guide and all parameters.
+> Configuration (deployment mode, database, ingress/TLS, etc.) is set in your values file. See the [chart README](charts/hoppscotch/README.md) for the full guide and all parameters.
 >
 > - **Load balancer / ingress:** use an ALB (`aio.ingress.ingressClassName: alb` + `alb.ingress.kubernetes.io/*`, AWS Load Balancer Controller required) or an NLB via `aio.service.type: LoadBalancer` with `service.beta.kubernetes.io/aws-load-balancer-*` under `aio.service.annotations`. In `distributed` mode the same keys exist per component.
 
@@ -180,7 +180,7 @@ helm repo add hoppscotch https://hoppscotch.github.io/helm-charts
 helm install [RELEASE_NAME] hoppscotch/hoppscotch -f [path-to-values-file]
 ```
 
-> Configuration (deployment mode, database, ingress/TLS, etc.) is set in your values file — see the [chart README](charts/hoppscotch/README.md) for the full guide and all parameters.
+> Configuration (deployment mode, database, ingress/TLS, etc.) is set in your values file. See the [chart README](charts/hoppscotch/README.md) for the full guide and all parameters.
 >
 > - **Load balancer / ingress:** use Application Gateway ingress (`aio.ingress.ingressClassName: azure-application-gateway` + `appgw.ingress.kubernetes.io/*`) or an Azure LB via `aio.service.type: LoadBalancer` with `service.beta.kubernetes.io/azure-load-balancer-*` under `aio.service.annotations`. In `distributed` mode the same keys exist per component.
 
@@ -191,7 +191,7 @@ helm install [RELEASE_NAME] hoppscotch/hoppscotch -f [path-to-values-file]
 
 **Prerequisites**
 
-- OpenShift 4.x cluster (works on the default `restricted-v2` SCC — no cluster-admin required)
+- OpenShift 4.x cluster (works on the default `restricted-v2` SCC; no cluster-admin required)
 - oc CLI logged in to your cluster
 - Helm 3.x installed
 
@@ -209,7 +209,7 @@ helm upgrade --install [RELEASE_NAME] hoppscotch/hoppscotch \
 
 On OpenShift, enable `global.compatibility.openshift.adaptSecurityContext` and expose the app with a Route
 instead of an Ingress. See the chart's [Deploying on OpenShift](charts/hoppscotch/README.md#deploying-on-openshift)
-guide for the full walkthrough — `restricted-v2` requirements, `HOPP_ALTERNATE_PORT`, and both `aio` and
+guide for the full walkthrough: `restricted-v2` requirements, `HOPP_ALTERNATE_PORT`, and both `aio` and
 `distributed` modes.
 
 </details>

--- a/charts/hoppscotch/README.md
+++ b/charts/hoppscotch/README.md
@@ -1,7 +1,7 @@
 # Hoppscotch Helm Chart
 
-![Version: 0.2.6](https://img.shields.io/badge/Version-0.2.6-informational?style=flat-square)
-![AppVersion: 2025.12.1](https://img.shields.io/badge/AppVersion-2025.12.1-informational?style=flat-square)
+![Version: 0.3.9](https://img.shields.io/badge/Version-0.3.9-informational?style=flat-square)
+![AppVersion: 2026.5.0](https://img.shields.io/badge/AppVersion-2026.5.0-informational?style=flat-square)
 
 Hoppscotch is a lightweight, web-based API development suite. It was built from the ground up with ease of use and
 accessibility in mind providing all the functionality needed for developers with minimalist, unobtrusive UI.
@@ -394,18 +394,80 @@ for the migrations job to complete.
 Instead the migration job is triggered by appending the release revision number to the job name to ensure that it is
 unique for each release. This allows the job to be run multiple times without conflicts.
 
+### Deploying on OpenShift
+
+The chart is compatible with both vanilla Kubernetes and
+[Red Hat OpenShift](https://www.redhat.com/en/technologies/cloud-computing/openshift). On OpenShift, the `restricted-v2`
+Security Context Constraint (SCC) assigns a random UID/GID and `fsGroup` from the namespace's allowed range and forbids
+hardcoding them. To make the chart and its Bitnami dependencies (PostgreSQL, Redis, ClickHouse) compatible, set the
+OpenShift compatibility mode:
+
+```yaml
+global:
+  compatibility:
+    openshift:
+      # auto: adapt only when an OpenShift cluster is detected (default)
+      # force: always adapt
+      # disabled: never adapt
+      adaptSecurityContext: auto
+```
+
+When adaptation is active, the chart removes `runAsUser`, `runAsGroup` and `fsGroup` from every `securityContext` so the
+platform can assign the allowed IDs. The default `auto` value only adapts when an OpenShift cluster is detected (via the
+`security.openshift.io/v1` API), so the same values file works unchanged on plain Kubernetes.
+
+#### Exposing services with OpenShift Routes
+
+In addition to standard `Ingress`, the chart can create native OpenShift
+[Route](https://docs.openshift.com/container-platform/latest/networking/routes/route-configuration.html) resources.
+Routes are an alternative to ingress and are disabled by default:
+
+```yaml
+deploymentMode: aio
+aio:
+  route:
+    enabled: true
+    host: "" # auto-assigned by OpenShift when empty
+    targetPort: http
+    tls:
+      enabled: true
+      termination: edge
+      insecureEdgeTerminationPolicy: Redirect
+```
+
+In `distributed` mode, configure `frontend.route`, `backend.route` and `admin.route` instead.
+
+#### Port binding considerations
+
+In AIO subpath mode (default), the container serves on privileged port `80`. OpenShift's `restricted-v2` SCC runs
+containers as a non-root user that cannot bind ports below `1024`. If the container image cannot bind port `80` as
+non-root, use AIO multiport mode (or `distributed` mode), whose services listen on unprivileged ports (`3000`, `3100`,
+`3170`, `3200`):
+
+```yaml
+deploymentMode: aio
+hoppscotch:
+  frontend:
+    enableSubpathBasedAccess: false
+aio:
+  route:
+    enabled: true
+    targetPort: http-frontend
+```
+
 ## Parameters
 
 <!-- markdownlint-disable MD013 MD034 -->
 
 ### Global Parameters
 
-| Key                                 | Type   | Default | Description                                         |
-| ----------------------------------- | ------ | ------- | --------------------------------------------------- |
-| global.imageRegistry                | string | `""`    | Global Docker image registry                        |
-| global.imagePullSecrets             | list   | `[]`    | Global Docker registry secret names as an array     |
-| global.defaultStorageClass          | string | `""`    | Global default storage class for persistent volumes |
-| global.security.allowInsecureImages | bool   | `false` | Allows skipping image verification                  |
+| Key                                                 | Type   | Default  | Description                                                                                                                                                                                                                                                                                                                                                         |
+| --------------------------------------------------- | ------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| global.imageRegistry                                | string | `""`     | Global Docker image registry                                                                                                                                                                                                                                                                                                                                        |
+| global.imagePullSecrets                             | list   | `[]`     | Global Docker registry secret names as an array                                                                                                                                                                                                                                                                                                                     |
+| global.defaultStorageClass                          | string | `""`     | Global default storage class for persistent volumes                                                                                                                                                                                                                                                                                                                 |
+| global.security.allowInsecureImages                 | bool   | `false`  | Allows skipping image verification                                                                                                                                                                                                                                                                                                                                  |
+| global.compatibility.openshift.adaptSecurityContext | string | `"auto"` | Adapt the securityContext sections of Hoppscotch and its dependencies to be compatible with OpenShift restricted-v2 SCC: removes `runAsUser`, `runAsGroup` and `fsGroup` so the platform assigns IDs from the namespace's allowed range. Possible values: `auto` (apply only if an OpenShift cluster is detected), `force` (always apply), `disabled` (never apply) |
 
 ### Common Parameters
 
@@ -594,6 +656,15 @@ unique for each release. This allows the job to be run multiple times without co
 | aio.ingress.extraTls                              | list   | `[]`                       | Extra TLS configurations for ingress                                                                                        |
 | aio.ingress.secrets                               | list   | `[]`                       | TLS secrets for ingress                                                                                                     |
 | aio.ingress.extraRules                            | list   | `[]`                       | Extra ingress rules                                                                                                         |
+| aio.route.enabled                                 | bool   | `false`                    | Enable OpenShift Route for Hoppscotch (OpenShift only, alternative to ingress)                                              |
+| aio.route.host                                    | string | `""`                       | Route hostname (auto-assigned by OpenShift when left empty)                                                                 |
+| aio.route.path                                    | string | `""`                       | Route path                                                                                                                  |
+| aio.route.targetPort                              | string | `"http"`                   | Service target port name or number the Route forwards to                                                                    |
+| aio.route.wildcardPolicy                          | string | `"None"`                   | Route wildcard policy (None or Subdomain)                                                                                   |
+| aio.route.annotations                             | object | `{}`                       | Route annotations                                                                                                           |
+| aio.route.tls.enabled                             | bool   | `true`                     | Enable TLS for the Route                                                                                                    |
+| aio.route.tls.termination                         | string | `"edge"`                   | TLS termination type (edge, passthrough or reencrypt)                                                                       |
+| aio.route.tls.insecureEdgeTerminationPolicy       | string | `"Redirect"`               | Insecure traffic policy (None, Allow or Redirect)                                                                           |
 | aio.persistence.enabled                           | bool   | `false`                    | Enable persistent storage for Hoppscotch                                                                                    |
 | aio.persistence.storageClass                      | string | `""`                       | Storage class for persistent volume                                                                                         |
 | aio.persistence.accessModes                       | list   | `["ReadWriteOnce"]`        | Access modes for persistent volume                                                                                          |
@@ -697,6 +768,15 @@ unique for each release. This allows the job to be run multiple times without co
 | frontend.ingress.extraTls                              | list   | `[]`                               | Extra TLS configurations for ingress                                                                                        |
 | frontend.ingress.secrets                               | list   | `[]`                               | TLS secrets for ingress                                                                                                     |
 | frontend.ingress.extraRules                            | list   | `[]`                               | Extra ingress rules                                                                                                         |
+| frontend.route.enabled                                 | bool   | `false`                            | Enable OpenShift Route for Hoppscotch (OpenShift only, alternative to ingress)                                              |
+| frontend.route.host                                    | string | `""`                               | Route hostname (auto-assigned by OpenShift when left empty)                                                                 |
+| frontend.route.path                                    | string | `""`                               | Route path                                                                                                                  |
+| frontend.route.targetPort                              | string | `"http"`                           | Service target port name or number the Route forwards to                                                                    |
+| frontend.route.wildcardPolicy                          | string | `"None"`                           | Route wildcard policy (None or Subdomain)                                                                                   |
+| frontend.route.annotations                             | object | `{}`                               | Route annotations                                                                                                           |
+| frontend.route.tls.enabled                             | bool   | `true`                             | Enable TLS for the Route                                                                                                    |
+| frontend.route.tls.termination                         | string | `"edge"`                           | TLS termination type (edge, passthrough or reencrypt)                                                                       |
+| frontend.route.tls.insecureEdgeTerminationPolicy       | string | `"Redirect"`                       | Insecure traffic policy (None, Allow or Redirect)                                                                           |
 | frontend.persistence.enabled                           | bool   | `false`                            | Enable persistent storage for Hoppscotch                                                                                    |
 | frontend.persistence.storageClass                      | string | `""`                               | Storage class for persistent volume                                                                                         |
 | frontend.persistence.accessModes                       | list   | `["ReadWriteOnce"]`                | Access modes for persistent volume                                                                                          |
@@ -800,6 +880,15 @@ unique for each release. This allows the job to be run multiple times without co
 | backend.ingress.extraTls                              | list   | `[]`                              | Extra TLS configurations for ingress                                                                                        |
 | backend.ingress.secrets                               | list   | `[]`                              | TLS secrets for ingress                                                                                                     |
 | backend.ingress.extraRules                            | list   | `[]`                              | Extra ingress rules                                                                                                         |
+| backend.route.enabled                                 | bool   | `false`                           | Enable OpenShift Route for Hoppscotch (OpenShift only, alternative to ingress)                                              |
+| backend.route.host                                    | string | `""`                              | Route hostname (auto-assigned by OpenShift when left empty)                                                                 |
+| backend.route.path                                    | string | `""`                              | Route path                                                                                                                  |
+| backend.route.targetPort                              | string | `"http"`                          | Service target port name or number the Route forwards to                                                                    |
+| backend.route.wildcardPolicy                          | string | `"None"`                          | Route wildcard policy (None or Subdomain)                                                                                   |
+| backend.route.annotations                             | object | `{}`                              | Route annotations                                                                                                           |
+| backend.route.tls.enabled                             | bool   | `true`                            | Enable TLS for the Route                                                                                                    |
+| backend.route.tls.termination                         | string | `"edge"`                          | TLS termination type (edge, passthrough or reencrypt)                                                                       |
+| backend.route.tls.insecureEdgeTerminationPolicy       | string | `"Redirect"`                      | Insecure traffic policy (None, Allow or Redirect)                                                                           |
 | backend.persistence.enabled                           | bool   | `false`                           | Enable persistent storage for Hoppscotch                                                                                    |
 | backend.persistence.storageClass                      | string | `""`                              | Storage class for persistent volume                                                                                         |
 | backend.persistence.accessModes                       | list   | `["ReadWriteOnce"]`               | Access modes for persistent volume                                                                                          |
@@ -903,6 +992,15 @@ unique for each release. This allows the job to be run multiple times without co
 | admin.ingress.extraTls                              | list   | `[]`                            | Extra TLS configurations for ingress                                                                                        |
 | admin.ingress.secrets                               | list   | `[]`                            | TLS secrets for ingress                                                                                                     |
 | admin.ingress.extraRules                            | list   | `[]`                            | Extra ingress rules                                                                                                         |
+| admin.route.enabled                                 | bool   | `false`                         | Enable OpenShift Route for Hoppscotch (OpenShift only, alternative to ingress)                                              |
+| admin.route.host                                    | string | `""`                            | Route hostname (auto-assigned by OpenShift when left empty)                                                                 |
+| admin.route.path                                    | string | `""`                            | Route path                                                                                                                  |
+| admin.route.targetPort                              | string | `"http"`                        | Service target port name or number the Route forwards to                                                                    |
+| admin.route.wildcardPolicy                          | string | `"None"`                        | Route wildcard policy (None or Subdomain)                                                                                   |
+| admin.route.annotations                             | object | `{}`                            | Route annotations                                                                                                           |
+| admin.route.tls.enabled                             | bool   | `true`                          | Enable TLS for the Route                                                                                                    |
+| admin.route.tls.termination                         | string | `"edge"`                        | TLS termination type (edge, passthrough or reencrypt)                                                                       |
+| admin.route.tls.insecureEdgeTerminationPolicy       | string | `"Redirect"`                    | Insecure traffic policy (None, Allow or Redirect)                                                                           |
 | admin.persistence.enabled                           | bool   | `false`                         | Enable persistent storage for Hoppscotch                                                                                    |
 | admin.persistence.storageClass                      | string | `""`                            | Storage class for persistent volume                                                                                         |
 | admin.persistence.accessModes                       | list   | `["ReadWriteOnce"]`             | Access modes for persistent volume                                                                                          |

--- a/charts/hoppscotch/README.md
+++ b/charts/hoppscotch/README.md
@@ -416,6 +416,137 @@ When adaptation is active, the chart removes `runAsUser`, `runAsGroup` and `fsGr
 platform can assign the allowed IDs. The default `auto` value only adapts when an OpenShift cluster is detected (via the
 `security.openshift.io/v1` API), so the same values file works unchanged on plain Kubernetes.
 
+#### Installation walkthrough
+
+These steps deploy Hoppscotch on a project that uses the default `restricted-v2` SCC — no cluster administrator or
+elevated SCC required. Both `aio` and `distributed` modes are supported.
+
+1. **Use OpenShift-compatible images.** `restricted-v2` runs the pod as a random non-root UID that cannot bind
+   privileged ports (below `1024`) or write into a root-owned image filesystem. Recent Hoppscotch images serve on an
+   unprivileged port via the `HOPP_ALTERNATE_PORT` environment variable and keep their application directory
+   group-writable, satisfying both requirements. Older images may need a workaround — see
+   [Container image requirements](#container-image-requirements).
+
+2. **Enable OpenShift compatibility** so `runAsUser`, `runAsGroup` and `fsGroup` are dropped and the platform assigns
+   IDs from the namespace range:
+
+   ```yaml
+   global:
+     compatibility:
+       openshift:
+         adaptSecurityContext: auto
+   ```
+
+3. **Serve on unprivileged ports.** On `restricted-v2` a component cannot bind privileged port `80`.
+   `HOPP_ALTERNATE_PORT` relocates a component's port-`80` listener to an unprivileged port **of your choice** (it is
+   configurable, not a fixed value — `3080` is only an example). Set it **only** for images that would otherwise bind
+   port `80`, and point that component's `containerPorts.http`, `service.ports.http` and `route.targetPort` at the same
+   value. Images that already serve on an unprivileged port ignore it — see the distributed `frontend` below.
+
+   All-in-one (subpath mode binds port `80`, so relocate it):
+
+   ```yaml
+   deploymentMode: aio
+   aio:
+     extraEnvVars:
+       - name: HOPP_ALTERNATE_PORT
+         value: "3080"
+     containerPorts:
+       http: 3080
+     route:
+       enabled: true
+       targetPort: http
+       tls:
+         enabled: true
+         termination: edge
+         insecureEdgeTerminationPolicy: Redirect
+   ```
+
+   Distributed — the `frontend`, `backend` and `admin` images all bind port `80`, so relocate each of them with
+   `HOPP_ALTERNATE_PORT`:
+
+   ```yaml
+   deploymentMode: distributed
+   frontend:
+     extraEnvVars:
+       - name: HOPP_ALTERNATE_PORT
+         value: "3080"
+     containerPorts:
+       http: 3080
+     service:
+       ports:
+         http: 3080
+     route:
+       enabled: true
+       targetPort: http
+       tls:
+         enabled: true
+         termination: edge
+         insecureEdgeTerminationPolicy: Redirect
+   backend:
+     extraEnvVars:
+       - name: HOPP_ALTERNATE_PORT
+         value: "3080"
+     containerPorts:
+       http: 3080
+     service:
+       ports:
+         http: 3080
+     route:
+       enabled: true
+       targetPort: http
+       tls:
+         enabled: true
+         termination: edge
+         insecureEdgeTerminationPolicy: Redirect
+   admin:
+     extraEnvVars:
+       - name: HOPP_ALTERNATE_PORT
+         value: "3080"
+     containerPorts:
+       http: 3080
+     service:
+       ports:
+         http: 3080
+     route:
+       enabled: true
+       targetPort: http
+       tls:
+         enabled: true
+         termination: edge
+         insecureEdgeTerminationPolicy: Redirect
+   ```
+
+4. **Set the public URLs.** Routes do not auto-populate the config URLs, so set them to the Route hostnames, which
+   follow `<service-name>-<namespace>.<router-domain>`. Get the router domain with:
+
+   ```bash
+   oc whoami --show-console | sed 's#https://console-openshift-console\.##'
+   ```
+
+   In `aio` mode a single host serves the frontend (`/`), backend (`/backend`) and admin (`/admin`) via subpaths. In
+   `distributed` mode point `hoppscotch.frontend.*` at the separate frontend, backend and admin Route hosts and set
+   `hoppscotch.backend.redirectUrl` / `hoppscotch.backend.whitelistedOrigins` to match. See
+   [Auto-Generating Config URLs](#auto-generating-config-urls) for the full list of keys.
+
+5. **Install:**
+
+   ```bash
+   helm upgrade --install hoppscotch hoppscotch/hoppscotch \
+     --namespace hoppscotch --create-namespace \
+     -f values.yaml
+   ```
+
+6. **Verify:**
+
+   ```bash
+   oc get pods -n hoppscotch     # migrations Completed; components Running
+   oc get route -n hoppscotch    # one Route (aio) or three (distributed)
+   ```
+
+   Browse to the frontend Route to confirm the UI loads. The backend health endpoint is `/ping` (`/backend/ping` in
+   `aio` subpath mode).
+
 #### Exposing services with OpenShift Routes
 
 In addition to standard `Ingress`, the chart can create native OpenShift
@@ -437,16 +568,18 @@ aio:
 
 In `distributed` mode, configure `frontend.route`, `backend.route` and `admin.route` instead.
 
-Routes are only rendered on clusters that expose the `route.openshift.io/v1` API, so enabling them in a
-values file shared with plain Kubernetes is a no-op there rather than a failed install. When previewing a
-Route offline with `helm template`, pass `--api-versions route.openshift.io/v1` so it renders.
+Routes are only rendered on clusters that expose the `route.openshift.io/v1` API, so enabling them in a values file
+shared with plain Kubernetes is a no-op there rather than a failed install. When previewing a Route offline with
+`helm template`, pass `--api-versions route.openshift.io/v1` so it renders.
 
 #### Port binding considerations
 
-In AIO subpath mode (default), the container serves on privileged port `80`. OpenShift's `restricted-v2` SCC runs
-containers as a non-root user that cannot bind ports below `1024`. If the container image cannot bind port `80` as
-non-root, use AIO multiport mode (or `distributed` mode), whose services listen on unprivileged ports (`3000`, `3100`,
-`3170`, `3200`):
+`restricted-v2` forbids binding privileged ports (below `1024`), so any component that would otherwise serve on port
+`80` must be relocated to an unprivileged port with `HOPP_ALTERNATE_PORT`. Step 3 of the
+[installation walkthrough](#installation-walkthrough) covers the per-component settings.
+
+If an image cannot relocate its port, an alternative is AIO **multiport** mode, whose services listen on unprivileged
+ports (`3000`, `3100`, `3170`, `3200`) directly:
 
 ```yaml
 deploymentMode: aio
@@ -461,29 +594,20 @@ aio:
 
 #### Container image requirements
 
-Under `restricted-v2` the container also runs with a random UID that does not own the image filesystem. At
-startup the all-in-one image writes a `build.env` file into its application directory (`/usr/src/app`); when
-that path is not writable by the assigned UID the pod fails with `EACCES: permission denied, open 'build.env'`.
-Stock Hoppscotch images are not yet arbitrary-UID-safe, so on `restricted-v2` use one of the following:
+Under `restricted-v2` the container runs with a random non-root UID that does not own the image filesystem and cannot
+bind privileged ports. Hoppscotch images with non-root container support keep their application directory group-writable
+and can serve on the port set by `HOPP_ALTERNATE_PORT`, so they run on `restricted-v2` without the `anyuid` SCC or a
+rebuilt image — **use these images (or newer).** You still relocate the privileged port with `HOPP_ALTERNATE_PORT` as
+shown in step 3 of the [installation walkthrough](#installation-walkthrough).
 
-- Grant the release ServiceAccount the `anyuid` SCC (requires a cluster administrator), which runs the
-  container as the image's own user:
+Older images that are not arbitrary-UID-safe write a `build.env` file into their application directory (`/usr/src/app`)
+at startup and fail with `EACCES: permission denied, open 'build.env'`, and they still bind privileged port `80`. To run
+such an image, grant the release ServiceAccount the `anyuid` SCC (requires a cluster administrator), which runs the
+container as the image's own user so it can both write its files and bind port `80`:
 
-  ```bash
-  oc adm policy add-scc-to-user anyuid -z <serviceAccountName> -n <namespace>
-  ```
-
-- Or build a thin derived image that makes the application directory writable by the root group (GID `0`),
-  which the UID assigned by OpenShift always belongs to:
-
-  ```dockerfile
-  FROM hoppscotch/hoppscotch:latest
-  USER root
-  RUN chgrp -R 0 /usr/src/app && chmod -R g=u /usr/src/app
-  ```
-
-  Point `aio.image` (or the distributed component images) at the result. The long-term fix is for the upstream
-  images to apply the same adjustment, after which no workaround is needed.
+```bash
+oc adm policy add-scc-to-user anyuid -z <serviceAccountName> -n <namespace>
+```
 
 ## Parameters
 

--- a/charts/hoppscotch/README.md
+++ b/charts/hoppscotch/README.md
@@ -459,6 +459,32 @@ aio:
     targetPort: http-frontend
 ```
 
+#### Container image requirements
+
+Under `restricted-v2` the container also runs with a random UID that does not own the image filesystem. At
+startup the all-in-one image writes a `build.env` file into its application directory (`/usr/src/app`); when
+that path is not writable by the assigned UID the pod fails with `EACCES: permission denied, open 'build.env'`.
+Stock Hoppscotch images are not yet arbitrary-UID-safe, so on `restricted-v2` use one of the following:
+
+- Grant the release ServiceAccount the `anyuid` SCC (requires a cluster administrator), which runs the
+  container as the image's own user:
+
+  ```bash
+  oc adm policy add-scc-to-user anyuid -z <serviceAccountName> -n <namespace>
+  ```
+
+- Or build a thin derived image that makes the application directory writable by the root group (GID `0`),
+  which the UID assigned by OpenShift always belongs to:
+
+  ```dockerfile
+  FROM hoppscotch/hoppscotch:latest
+  USER root
+  RUN chgrp -R 0 /usr/src/app && chmod -R g=u /usr/src/app
+  ```
+
+  Point `aio.image` (or the distributed component images) at the result. The long-term fix is for the upstream
+  images to apply the same adjustment, after which no workaround is needed.
+
 ## Parameters
 
 <!-- markdownlint-disable MD013 MD034 -->

--- a/charts/hoppscotch/README.md
+++ b/charts/hoppscotch/README.md
@@ -437,6 +437,10 @@ aio:
 
 In `distributed` mode, configure `frontend.route`, `backend.route` and `admin.route` instead.
 
+Routes are only rendered on clusters that expose the `route.openshift.io/v1` API, so enabling them in a
+values file shared with plain Kubernetes is a no-op there rather than a failed install. When previewing a
+Route offline with `helm template`, pass `--api-versions route.openshift.io/v1` so it renders.
+
 #### Port binding considerations
 
 In AIO subpath mode (default), the container serves on privileged port `80`. OpenShift's `restricted-v2` SCC runs

--- a/charts/hoppscotch/README.md
+++ b/charts/hoppscotch/README.md
@@ -1,7 +1,7 @@
 # Hoppscotch Helm Chart
 
-![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square)
-![AppVersion: 2026.6.0](https://img.shields.io/badge/AppVersion-2026.6.0-informational?style=flat-square)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square)
+![AppVersion: 2026.6.1](https://img.shields.io/badge/AppVersion-2026.6.1-informational?style=flat-square)
 
 Hoppscotch is a lightweight, web-based API development suite. It was built from the ground up with ease of use and
 accessibility in mind providing all the functionality needed for developers with minimalist, unobtrusive UI.
@@ -422,10 +422,10 @@ These steps deploy Hoppscotch on a project that uses the default `restricted-v2`
 elevated SCC required. Both `aio` and `distributed` modes are supported.
 
 1. **Use OpenShift-compatible images.** `restricted-v2` runs the pod as a random non-root UID that cannot bind
-   privileged ports (below `1024`) or write into a root-owned image filesystem. Recent Hoppscotch images serve on an
-   unprivileged port via the `HOPP_ALTERNATE_PORT` environment variable and keep their application directory
-   group-writable, satisfying both requirements. Older images may need a workaround; see
-   [Container image requirements](#container-image-requirements).
+   privileged ports (below `1024`) or write into a root-owned image filesystem. Hoppscotch images from app version
+   `2026.6.1` onwards serve on an unprivileged port via the `HOPP_ALTERNATE_PORT` environment variable and keep their
+   application directory group-writable, satisfying both requirements. Images older than `2026.6.1` may need a
+   workaround; see [Container image requirements](#container-image-requirements).
 
 2. **Enable OpenShift compatibility** so `runAsUser`, `runAsGroup` and `fsGroup` are dropped and the platform assigns
    IDs from the namespace range:
@@ -595,15 +595,16 @@ aio:
 #### Container image requirements
 
 Under `restricted-v2` the container runs with a random non-root UID that does not own the image filesystem and cannot
-bind privileged ports. Hoppscotch images with non-root container support keep their application directory group-writable
-and can serve on the port set by `HOPP_ALTERNATE_PORT`, so they run on `restricted-v2` without the `anyuid` SCC or a
-rebuilt image. **Use these images (or newer).** You still relocate the privileged port with `HOPP_ALTERNATE_PORT` as
-shown in step 3 of the [installation walkthrough](#installation-walkthrough).
+bind privileged ports. Hoppscotch added non-root container support in **app version `2026.6.1`**, so images at
+`2026.6.1` or newer keep their application directory group-writable and can serve on the port set by
+`HOPP_ALTERNATE_PORT`. They run on `restricted-v2` without the `anyuid` SCC or a rebuilt image. **Use `2026.6.1` or
+newer**, and still relocate the privileged port with `HOPP_ALTERNATE_PORT` as shown in step 3 of the
+[installation walkthrough](#installation-walkthrough).
 
-Older images that are not arbitrary-UID-safe write a `build.env` file into their application directory (`/usr/src/app`)
-at startup and fail with `EACCES: permission denied, open 'build.env'`, and they still bind privileged port `80`. To run
-such an image, grant the release ServiceAccount the `anyuid` SCC (requires a cluster administrator), which runs the
-container as the image's own user so it can both write its files and bind port `80`:
+Images older than `2026.6.1` are not arbitrary-UID-safe: they write a `build.env` file into their application directory
+(`/usr/src/app`) at startup and fail with `EACCES: permission denied, open 'build.env'`, and they still bind privileged
+port `80`. To run such an image, grant the release ServiceAccount the `anyuid` SCC (requires a cluster administrator),
+which runs the container as the image's own user so it can both write its files and bind port `80`:
 
 ```bash
 oc adm policy add-scc-to-user anyuid -z <serviceAccountName> -n <namespace>

--- a/charts/hoppscotch/README.md
+++ b/charts/hoppscotch/README.md
@@ -418,13 +418,13 @@ platform can assign the allowed IDs. The default `auto` value only adapts when a
 
 #### Installation walkthrough
 
-These steps deploy Hoppscotch on a project that uses the default `restricted-v2` SCC — no cluster administrator or
+These steps deploy Hoppscotch on a project that uses the default `restricted-v2` SCC. No cluster administrator or
 elevated SCC required. Both `aio` and `distributed` modes are supported.
 
 1. **Use OpenShift-compatible images.** `restricted-v2` runs the pod as a random non-root UID that cannot bind
    privileged ports (below `1024`) or write into a root-owned image filesystem. Recent Hoppscotch images serve on an
    unprivileged port via the `HOPP_ALTERNATE_PORT` environment variable and keep their application directory
-   group-writable, satisfying both requirements. Older images may need a workaround — see
+   group-writable, satisfying both requirements. Older images may need a workaround; see
    [Container image requirements](#container-image-requirements).
 
 2. **Enable OpenShift compatibility** so `runAsUser`, `runAsGroup` and `fsGroup` are dropped and the platform assigns
@@ -439,9 +439,9 @@ elevated SCC required. Both `aio` and `distributed` modes are supported.
 
 3. **Serve on unprivileged ports.** On `restricted-v2` a component cannot bind privileged port `80`.
    `HOPP_ALTERNATE_PORT` relocates a component's port-`80` listener to an unprivileged port **of your choice** (it is
-   configurable, not a fixed value — `3080` is only an example). Set it **only** for images that would otherwise bind
+   configurable, not a fixed value; `3080` is only an example). Set it **only** for images that would otherwise bind
    port `80`, and point that component's `containerPorts.http`, `service.ports.http` and `route.targetPort` at the same
-   value. Images that already serve on an unprivileged port ignore it — see the distributed `frontend` below.
+   value. Images that already serve on an unprivileged port ignore it; see the distributed `frontend` below.
 
    All-in-one (subpath mode binds port `80`, so relocate it):
 
@@ -462,7 +462,7 @@ elevated SCC required. Both `aio` and `distributed` modes are supported.
          insecureEdgeTerminationPolicy: Redirect
    ```
 
-   Distributed — the `frontend`, `backend` and `admin` images all bind port `80`, so relocate each of them with
+   In distributed mode, the `frontend`, `backend` and `admin` images all bind port `80`, so relocate each of them with
    `HOPP_ALTERNATE_PORT`:
 
    ```yaml
@@ -597,7 +597,7 @@ aio:
 Under `restricted-v2` the container runs with a random non-root UID that does not own the image filesystem and cannot
 bind privileged ports. Hoppscotch images with non-root container support keep their application directory group-writable
 and can serve on the port set by `HOPP_ALTERNATE_PORT`, so they run on `restricted-v2` without the `anyuid` SCC or a
-rebuilt image — **use these images (or newer).** You still relocate the privileged port with `HOPP_ALTERNATE_PORT` as
+rebuilt image. **Use these images (or newer).** You still relocate the privileged port with `HOPP_ALTERNATE_PORT` as
 shown in step 3 of the [installation walkthrough](#installation-walkthrough).
 
 Older images that are not arbitrary-UID-safe write a `build.env` file into their application directory (`/usr/src/app`)

--- a/charts/hoppscotch/README.md.gotmpl
+++ b/charts/hoppscotch/README.md.gotmpl
@@ -415,6 +415,138 @@ When adaptation is active, the chart removes `runAsUser`, `runAsGroup` and `fsGr
 OpenShift cluster is detected (via the `security.openshift.io/v1` API), so the same values file works
 unchanged on plain Kubernetes.
 
+#### Installation walkthrough
+
+These steps deploy Hoppscotch on a project that uses the default `restricted-v2` SCC — no cluster
+administrator or elevated SCC required. Both `aio` and `distributed` modes are supported.
+
+1. **Use OpenShift-compatible images.** `restricted-v2` runs the pod as a random non-root UID that cannot
+   bind privileged ports (below `1024`) or write into a root-owned image filesystem. Recent Hoppscotch
+   images serve on an unprivileged port via the `HOPP_ALTERNATE_PORT` environment variable and keep their
+   application directory group-writable, satisfying both requirements. Older images may need a workaround —
+   see [Container image requirements](#container-image-requirements).
+
+2. **Enable OpenShift compatibility** so `runAsUser`, `runAsGroup` and `fsGroup` are dropped and the
+   platform assigns IDs from the namespace range:
+
+   ```yaml
+   global:
+     compatibility:
+       openshift:
+         adaptSecurityContext: auto
+   ```
+
+3. **Serve on unprivileged ports.** On `restricted-v2` a component cannot bind privileged port `80`.
+   `HOPP_ALTERNATE_PORT` relocates a component's port-`80` listener to an unprivileged port **of your choice**
+   (it is configurable, not a fixed value — `3080` is only an example). Set it **only** for images that would
+   otherwise bind port `80`, and point that component's `containerPorts.http`, `service.ports.http` and
+   `route.targetPort` at the same value. Images that already serve on an unprivileged port ignore it — see the
+   distributed `frontend` below.
+
+   All-in-one (subpath mode binds port `80`, so relocate it):
+
+   ```yaml
+   deploymentMode: aio
+   aio:
+     extraEnvVars:
+       - name: HOPP_ALTERNATE_PORT
+         value: "3080"
+     containerPorts:
+       http: 3080
+     route:
+       enabled: true
+       targetPort: http
+       tls:
+         enabled: true
+         termination: edge
+         insecureEdgeTerminationPolicy: Redirect
+   ```
+
+   Distributed — the `frontend`, `backend` and `admin` images all bind port `80`, so relocate each of them
+   with `HOPP_ALTERNATE_PORT`:
+
+   ```yaml
+   deploymentMode: distributed
+   frontend:
+     extraEnvVars:
+       - name: HOPP_ALTERNATE_PORT
+         value: "3080"
+     containerPorts:
+       http: 3080
+     service:
+       ports:
+         http: 3080
+     route:
+       enabled: true
+       targetPort: http
+       tls:
+         enabled: true
+         termination: edge
+         insecureEdgeTerminationPolicy: Redirect
+   backend:
+     extraEnvVars:
+       - name: HOPP_ALTERNATE_PORT
+         value: "3080"
+     containerPorts:
+       http: 3080
+     service:
+       ports:
+         http: 3080
+     route:
+       enabled: true
+       targetPort: http
+       tls:
+         enabled: true
+         termination: edge
+         insecureEdgeTerminationPolicy: Redirect
+   admin:
+     extraEnvVars:
+       - name: HOPP_ALTERNATE_PORT
+         value: "3080"
+     containerPorts:
+       http: 3080
+     service:
+       ports:
+         http: 3080
+     route:
+       enabled: true
+       targetPort: http
+       tls:
+         enabled: true
+         termination: edge
+         insecureEdgeTerminationPolicy: Redirect
+   ```
+
+4. **Set the public URLs.** Routes do not auto-populate the config URLs, so set them to the Route hostnames,
+   which follow `<service-name>-<namespace>.<router-domain>`. Get the router domain with:
+
+   ```bash
+   oc whoami --show-console | sed 's#https://console-openshift-console\.##'
+   ```
+
+   In `aio` mode a single host serves the frontend (`/`), backend (`/backend`) and admin (`/admin`) via
+   subpaths. In `distributed` mode point `hoppscotch.frontend.*` at the separate frontend, backend and admin
+   Route hosts and set `hoppscotch.backend.redirectUrl` / `hoppscotch.backend.whitelistedOrigins` to match.
+   See [Auto-Generating Config URLs](#auto-generating-config-urls) for the full list of keys.
+
+5. **Install:**
+
+   ```bash
+   helm upgrade --install hoppscotch hoppscotch/hoppscotch \
+     --namespace hoppscotch --create-namespace \
+     -f values.yaml
+   ```
+
+6. **Verify:**
+
+   ```bash
+   oc get pods -n hoppscotch     # migrations Completed; components Running
+   oc get route -n hoppscotch    # one Route (aio) or three (distributed)
+   ```
+
+   Browse to the frontend Route to confirm the UI loads. The backend health endpoint is `/ping`
+   (`/backend/ping` in `aio` subpath mode).
+
 #### Exposing services with OpenShift Routes
 
 In addition to standard `Ingress`, the chart can create native OpenShift
@@ -442,10 +574,12 @@ Route offline with `helm template`, pass `--api-versions route.openshift.io/v1` 
 
 #### Port binding considerations
 
-In AIO subpath mode (default), the container serves on privileged port `80`. OpenShift's `restricted-v2`
-SCC runs containers as a non-root user that cannot bind ports below `1024`. If the container image cannot
-bind port `80` as non-root, use AIO multiport mode (or `distributed` mode), whose services listen on
-unprivileged ports (`3000`, `3100`, `3170`, `3200`):
+`restricted-v2` forbids binding privileged ports (below `1024`), so any component that would otherwise serve
+on port `80` must be relocated to an unprivileged port with `HOPP_ALTERNATE_PORT`. Step 3 of the
+[installation walkthrough](#installation-walkthrough) covers the per-component settings.
+
+If an image cannot relocate its port, an alternative is AIO **multiport** mode, whose services listen on
+unprivileged ports (`3000`, `3100`, `3170`, `3200`) directly:
 
 ```yaml
 deploymentMode: aio
@@ -460,29 +594,21 @@ aio:
 
 #### Container image requirements
 
-Under `restricted-v2` the container also runs with a random UID that does not own the image filesystem. At
-startup the all-in-one image writes a `build.env` file into its application directory (`/usr/src/app`); when
-that path is not writable by the assigned UID the pod fails with `EACCES: permission denied, open 'build.env'`.
-Stock Hoppscotch images are not yet arbitrary-UID-safe, so on `restricted-v2` use one of the following:
+Under `restricted-v2` the container runs with a random non-root UID that does not own the image filesystem and
+cannot bind privileged ports. Hoppscotch images with non-root container support keep their application directory group-writable and can
+serve on the port set by `HOPP_ALTERNATE_PORT`, so they run on `restricted-v2` without the `anyuid` SCC or a
+rebuilt image — **use these images (or newer).** You still relocate the privileged port with
+`HOPP_ALTERNATE_PORT` as shown in step 3 of the [installation walkthrough](#installation-walkthrough).
 
-- Grant the release ServiceAccount the `anyuid` SCC (requires a cluster administrator), which runs the
-  container as the image's own user:
+Older images that are not arbitrary-UID-safe write a `build.env` file into their application directory
+(`/usr/src/app`) at startup and fail with `EACCES: permission denied, open 'build.env'`, and they still bind
+privileged port `80`. To run such an image, grant the release ServiceAccount the `anyuid` SCC (requires a
+cluster administrator), which runs the container as the image's own user so it can both write its files and
+bind port `80`:
 
-  ```bash
-  oc adm policy add-scc-to-user anyuid -z <serviceAccountName> -n <namespace>
-  ```
-
-- Or build a thin derived image that makes the application directory writable by the root group (GID `0`),
-  which the UID assigned by OpenShift always belongs to:
-
-  ```dockerfile
-  FROM hoppscotch/hoppscotch:latest
-  USER root
-  RUN chgrp -R 0 /usr/src/app && chmod -R g=u /usr/src/app
-  ```
-
-  Point `aio.image` (or the distributed component images) at the result. The long-term fix is for the upstream
-  images to apply the same adjustment, after which no workaround is needed.
+```bash
+oc adm policy add-scc-to-user anyuid -z <serviceAccountName> -n <namespace>
+```
 
 ## Parameters
 

--- a/charts/hoppscotch/README.md.gotmpl
+++ b/charts/hoppscotch/README.md.gotmpl
@@ -417,13 +417,13 @@ unchanged on plain Kubernetes.
 
 #### Installation walkthrough
 
-These steps deploy Hoppscotch on a project that uses the default `restricted-v2` SCC — no cluster
+These steps deploy Hoppscotch on a project that uses the default `restricted-v2` SCC. No cluster
 administrator or elevated SCC required. Both `aio` and `distributed` modes are supported.
 
 1. **Use OpenShift-compatible images.** `restricted-v2` runs the pod as a random non-root UID that cannot
    bind privileged ports (below `1024`) or write into a root-owned image filesystem. Recent Hoppscotch
    images serve on an unprivileged port via the `HOPP_ALTERNATE_PORT` environment variable and keep their
-   application directory group-writable, satisfying both requirements. Older images may need a workaround —
+   application directory group-writable, satisfying both requirements. Older images may need a workaround;
    see [Container image requirements](#container-image-requirements).
 
 2. **Enable OpenShift compatibility** so `runAsUser`, `runAsGroup` and `fsGroup` are dropped and the
@@ -438,9 +438,9 @@ administrator or elevated SCC required. Both `aio` and `distributed` modes are s
 
 3. **Serve on unprivileged ports.** On `restricted-v2` a component cannot bind privileged port `80`.
    `HOPP_ALTERNATE_PORT` relocates a component's port-`80` listener to an unprivileged port **of your choice**
-   (it is configurable, not a fixed value — `3080` is only an example). Set it **only** for images that would
+   (it is configurable, not a fixed value; `3080` is only an example). Set it **only** for images that would
    otherwise bind port `80`, and point that component's `containerPorts.http`, `service.ports.http` and
-   `route.targetPort` at the same value. Images that already serve on an unprivileged port ignore it — see the
+   `route.targetPort` at the same value. Images that already serve on an unprivileged port ignore it; see the
    distributed `frontend` below.
 
    All-in-one (subpath mode binds port `80`, so relocate it):
@@ -462,7 +462,7 @@ administrator or elevated SCC required. Both `aio` and `distributed` modes are s
          insecureEdgeTerminationPolicy: Redirect
    ```
 
-   Distributed — the `frontend`, `backend` and `admin` images all bind port `80`, so relocate each of them
+   In distributed mode, the `frontend`, `backend` and `admin` images all bind port `80`, so relocate each of them
    with `HOPP_ALTERNATE_PORT`:
 
    ```yaml
@@ -597,7 +597,7 @@ aio:
 Under `restricted-v2` the container runs with a random non-root UID that does not own the image filesystem and
 cannot bind privileged ports. Hoppscotch images with non-root container support keep their application directory group-writable and can
 serve on the port set by `HOPP_ALTERNATE_PORT`, so they run on `restricted-v2` without the `anyuid` SCC or a
-rebuilt image — **use these images (or newer).** You still relocate the privileged port with
+rebuilt image. **Use these images (or newer).** You still relocate the privileged port with
 `HOPP_ALTERNATE_PORT` as shown in step 3 of the [installation walkthrough](#installation-walkthrough).
 
 Older images that are not arbitrary-UID-safe write a `build.env` file into their application directory

--- a/charts/hoppscotch/README.md.gotmpl
+++ b/charts/hoppscotch/README.md.gotmpl
@@ -436,6 +436,10 @@ aio:
 
 In `distributed` mode, configure `frontend.route`, `backend.route` and `admin.route` instead.
 
+Routes are only rendered on clusters that expose the `route.openshift.io/v1` API, so enabling them in a
+values file shared with plain Kubernetes is a no-op there rather than a failed install. When previewing a
+Route offline with `helm template`, pass `--api-versions route.openshift.io/v1` so it renders.
+
 #### Port binding considerations
 
 In AIO subpath mode (default), the container serves on privileged port `80`. OpenShift's `restricted-v2`

--- a/charts/hoppscotch/README.md.gotmpl
+++ b/charts/hoppscotch/README.md.gotmpl
@@ -421,10 +421,10 @@ These steps deploy Hoppscotch on a project that uses the default `restricted-v2`
 administrator or elevated SCC required. Both `aio` and `distributed` modes are supported.
 
 1. **Use OpenShift-compatible images.** `restricted-v2` runs the pod as a random non-root UID that cannot
-   bind privileged ports (below `1024`) or write into a root-owned image filesystem. Recent Hoppscotch
-   images serve on an unprivileged port via the `HOPP_ALTERNATE_PORT` environment variable and keep their
-   application directory group-writable, satisfying both requirements. Older images may need a workaround;
-   see [Container image requirements](#container-image-requirements).
+   bind privileged ports (below `1024`) or write into a root-owned image filesystem. Hoppscotch images from
+   app version `2026.6.1` onwards serve on an unprivileged port via the `HOPP_ALTERNATE_PORT` environment
+   variable and keep their application directory group-writable, satisfying both requirements. Images older
+   than `2026.6.1` may need a workaround; see [Container image requirements](#container-image-requirements).
 
 2. **Enable OpenShift compatibility** so `runAsUser`, `runAsGroup` and `fsGroup` are dropped and the
    platform assigns IDs from the namespace range:
@@ -595,14 +595,15 @@ aio:
 #### Container image requirements
 
 Under `restricted-v2` the container runs with a random non-root UID that does not own the image filesystem and
-cannot bind privileged ports. Hoppscotch images with non-root container support keep their application directory group-writable and can
-serve on the port set by `HOPP_ALTERNATE_PORT`, so they run on `restricted-v2` without the `anyuid` SCC or a
-rebuilt image. **Use these images (or newer).** You still relocate the privileged port with
-`HOPP_ALTERNATE_PORT` as shown in step 3 of the [installation walkthrough](#installation-walkthrough).
+cannot bind privileged ports. Hoppscotch added non-root container support in **app version `2026.6.1`**, so
+images at `2026.6.1` or newer keep their application directory group-writable and can serve on the port set by
+`HOPP_ALTERNATE_PORT`. They run on `restricted-v2` without the `anyuid` SCC or a rebuilt image. **Use
+`2026.6.1` or newer**, and still relocate the privileged port with `HOPP_ALTERNATE_PORT` as shown in step 3 of
+the [installation walkthrough](#installation-walkthrough).
 
-Older images that are not arbitrary-UID-safe write a `build.env` file into their application directory
-(`/usr/src/app`) at startup and fail with `EACCES: permission denied, open 'build.env'`, and they still bind
-privileged port `80`. To run such an image, grant the release ServiceAccount the `anyuid` SCC (requires a
+Images older than `2026.6.1` are not arbitrary-UID-safe: they write a `build.env` file into their application
+directory (`/usr/src/app`) at startup and fail with `EACCES: permission denied, open 'build.env'`, and they
+still bind privileged port `80`. To run such an image, grant the release ServiceAccount the `anyuid` SCC (requires a
 cluster administrator), which runs the container as the image's own user so it can both write its files and
 bind port `80`:
 

--- a/charts/hoppscotch/README.md.gotmpl
+++ b/charts/hoppscotch/README.md.gotmpl
@@ -458,6 +458,32 @@ aio:
     targetPort: http-frontend
 ```
 
+#### Container image requirements
+
+Under `restricted-v2` the container also runs with a random UID that does not own the image filesystem. At
+startup the all-in-one image writes a `build.env` file into its application directory (`/usr/src/app`); when
+that path is not writable by the assigned UID the pod fails with `EACCES: permission denied, open 'build.env'`.
+Stock Hoppscotch images are not yet arbitrary-UID-safe, so on `restricted-v2` use one of the following:
+
+- Grant the release ServiceAccount the `anyuid` SCC (requires a cluster administrator), which runs the
+  container as the image's own user:
+
+  ```bash
+  oc adm policy add-scc-to-user anyuid -z <serviceAccountName> -n <namespace>
+  ```
+
+- Or build a thin derived image that makes the application directory writable by the root group (GID `0`),
+  which the UID assigned by OpenShift always belongs to:
+
+  ```dockerfile
+  FROM hoppscotch/hoppscotch:latest
+  USER root
+  RUN chgrp -R 0 /usr/src/app && chmod -R g=u /usr/src/app
+  ```
+
+  Point `aio.image` (or the distributed component images) at the result. The long-term fix is for the upstream
+  images to apply the same adjustment, after which no workaround is needed.
+
 ## Parameters
 
 <!-- markdownlint-disable MD013 MD034 -->

--- a/charts/hoppscotch/README.md.gotmpl
+++ b/charts/hoppscotch/README.md.gotmpl
@@ -393,6 +393,67 @@ for the migrations job to complete.
 Instead the migration job is triggered by appending the release revision number to the job name to ensure that it is
 unique for each release. This allows the job to be run multiple times without conflicts.
 
+### Deploying on OpenShift
+
+The chart is compatible with both vanilla Kubernetes and [Red Hat OpenShift](https://www.redhat.com/en/technologies/cloud-computing/openshift).
+On OpenShift, the `restricted-v2` Security Context Constraint (SCC) assigns a random UID/GID and `fsGroup`
+from the namespace's allowed range and forbids hardcoding them. To make the chart and its Bitnami dependencies
+(PostgreSQL, Redis, ClickHouse) compatible, set the OpenShift compatibility mode:
+
+```yaml
+global:
+  compatibility:
+    openshift:
+      # auto: adapt only when an OpenShift cluster is detected (default)
+      # force: always adapt
+      # disabled: never adapt
+      adaptSecurityContext: auto
+```
+
+When adaptation is active, the chart removes `runAsUser`, `runAsGroup` and `fsGroup` from every
+`securityContext` so the platform can assign the allowed IDs. The default `auto` value only adapts when an
+OpenShift cluster is detected (via the `security.openshift.io/v1` API), so the same values file works
+unchanged on plain Kubernetes.
+
+#### Exposing services with OpenShift Routes
+
+In addition to standard `Ingress`, the chart can create native OpenShift
+[Route](https://docs.openshift.com/container-platform/latest/networking/routes/route-configuration.html)
+resources. Routes are an alternative to ingress and are disabled by default:
+
+```yaml
+deploymentMode: aio
+aio:
+  route:
+    enabled: true
+    host: "" # auto-assigned by OpenShift when empty
+    targetPort: http
+    tls:
+      enabled: true
+      termination: edge
+      insecureEdgeTerminationPolicy: Redirect
+```
+
+In `distributed` mode, configure `frontend.route`, `backend.route` and `admin.route` instead.
+
+#### Port binding considerations
+
+In AIO subpath mode (default), the container serves on privileged port `80`. OpenShift's `restricted-v2`
+SCC runs containers as a non-root user that cannot bind ports below `1024`. If the container image cannot
+bind port `80` as non-root, use AIO multiport mode (or `distributed` mode), whose services listen on
+unprivileged ports (`3000`, `3100`, `3170`, `3200`):
+
+```yaml
+deploymentMode: aio
+hoppscotch:
+  frontend:
+    enableSubpathBasedAccess: false
+aio:
+  route:
+    enabled: true
+    targetPort: http-frontend
+```
+
 ## Parameters
 
 <!-- markdownlint-disable MD013 MD034 -->

--- a/charts/hoppscotch/templates/_helpers.tpl
+++ b/charts/hoppscotch/templates/_helpers.tpl
@@ -47,7 +47,7 @@ Return true if the securityContext sections should be adapted for OpenShift base
 Usage: {{ include "hoppscotch.compatibility.shouldAdaptSecurityContext" . }}
 */}}
 {{- define "hoppscotch.compatibility.shouldAdaptSecurityContext" -}}
-  {{- $mode := dig "compatibility" "openshift" "adaptSecurityContext" "disabled" .Values.global -}}
+  {{- $mode := dig "compatibility" "openshift" "adaptSecurityContext" "auto" .Values.global -}}
   {{- if eq $mode "force" -}}
     {{- true -}}
   {{- else if and (eq $mode "auto") (include "hoppscotch.compatibility.isOpenshift" .) -}}

--- a/charts/hoppscotch/templates/_helpers.tpl
+++ b/charts/hoppscotch/templates/_helpers.tpl
@@ -33,6 +33,45 @@ Usage: {{ include "hoppscotch.hasCertManagerRequest" ( dict "annotations" .Value
 {{- end -}}
 
 {{/*
+Return true if the detected running cluster is OpenShift.
+*/}}
+{{- define "hoppscotch.compatibility.isOpenshift" -}}
+  {{- if .Capabilities.APIVersions.Has "security.openshift.io/v1/SecurityContextConstraints" -}}
+    {{- true -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Return true if the securityContext sections should be adapted for OpenShift based on
+`global.compatibility.openshift.adaptSecurityContext` and the detected cluster.
+Usage: {{ include "hoppscotch.compatibility.shouldAdaptSecurityContext" . }}
+*/}}
+{{- define "hoppscotch.compatibility.shouldAdaptSecurityContext" -}}
+  {{- $mode := dig "compatibility" "openshift" "adaptSecurityContext" "disabled" .Values.global -}}
+  {{- if eq $mode "force" -}}
+    {{- true -}}
+  {{- else if and (eq $mode "auto") (include "hoppscotch.compatibility.isOpenshift" .) -}}
+    {{- true -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Render a securityContext section, adapting it for OpenShift when required. When adaptation is
+active, `runAsUser`, `runAsGroup` and `fsGroup` are removed so the platform can assign IDs from the
+namespace's allowed range. Returns an empty string when the resulting context is empty.
+Usage: {{ include "hoppscotch.compatibility.renderSecurityContext" (dict "secContext" .Values.aio.podSecurityContext "context" $) }}
+*/}}
+{{- define "hoppscotch.compatibility.renderSecurityContext" -}}
+  {{- $adapted := omit .secContext "enabled" -}}
+  {{- if include "hoppscotch.compatibility.shouldAdaptSecurityContext" .context -}}
+    {{- $adapted = omit $adapted "fsGroup" "runAsUser" "runAsGroup" -}}
+  {{- end -}}
+  {{- if $adapted -}}
+    {{- toYaml $adapted -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
 Return the Hoppscotch container image name with tag. Chart app version is used as a default tag if not specified. This
 helper is intended to be used for Hoppscotch components only. For all other components use `hoppscotch.images.image`.
 Usage: {{ include "hoppscotch.image" (dict "component" .Values.frontend "context" .) }}

--- a/charts/hoppscotch/templates/admin/deployment.yaml
+++ b/charts/hoppscotch/templates/admin/deployment.yaml
@@ -44,15 +44,15 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "hoppscotch.serviceAccountName" . }}
-      {{- with .Values.admin.podSecurityContext }}
+      {{- with (include "hoppscotch.compatibility.renderSecurityContext" (dict "secContext" .Values.admin.podSecurityContext "context" $)) }}
       securityContext:
-        {{- toYaml . | nindent 8 }}
+        {{- . | nindent 8 }}
       {{- end }}
       containers:
         - name: hoppscotch
-          {{- with .Values.admin.securityContext }}
+          {{- with (include "hoppscotch.compatibility.renderSecurityContext" (dict "secContext" .Values.admin.securityContext "context" $)) }}
           securityContext:
-            {{- toYaml . | nindent 12 }}
+            {{- . | nindent 12 }}
           {{- end }}
           image: {{ include "hoppscotch.image" (dict "component" .Values.admin "context" .) }}
           imagePullPolicy: {{ .Values.admin.image.pullPolicy }}

--- a/charts/hoppscotch/templates/admin/route.yaml
+++ b/charts/hoppscotch/templates/admin/route.yaml
@@ -1,0 +1,38 @@
+{{- if and (eq .Values.deploymentMode "distributed") .Values.admin.route.enabled }}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ include "hoppscotch.admin.serviceName" . }}
+  namespace: {{ include "hoppscotch.namespace" . | quote }}
+  labels:
+    app.kubernetes.io/component: hoppscotch-admin
+    {{- include "hoppscotch.labels" . | nindent 4 }}
+  {{- if or .Values.commonAnnotations .Values.admin.route.annotations }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- toYaml .Values.commonAnnotations | nindent 4 }}
+    {{- end }}
+    {{- if .Values.admin.route.annotations }}
+    {{- toYaml .Values.admin.route.annotations | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  {{- if .Values.admin.route.host }}
+  host: {{ .Values.admin.route.host | quote }}
+  {{- end }}
+  {{- if .Values.admin.route.path }}
+  path: {{ .Values.admin.route.path | quote }}
+  {{- end }}
+  to:
+    kind: Service
+    name: {{ include "hoppscotch.admin.serviceName" . }}
+    weight: 100
+  port:
+    targetPort: {{ .Values.admin.route.targetPort }}
+  {{- if .Values.admin.route.tls.enabled }}
+  tls:
+    termination: {{ .Values.admin.route.tls.termination }}
+    insecureEdgeTerminationPolicy: {{ .Values.admin.route.tls.insecureEdgeTerminationPolicy }}
+  {{- end }}
+  wildcardPolicy: {{ .Values.admin.route.wildcardPolicy }}
+{{- end }}

--- a/charts/hoppscotch/templates/admin/route.yaml
+++ b/charts/hoppscotch/templates/admin/route.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq .Values.deploymentMode "distributed") .Values.admin.route.enabled }}
+{{- if and (eq .Values.deploymentMode "distributed") .Values.admin.route.enabled (.Capabilities.APIVersions.Has "route.openshift.io/v1") }}
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:

--- a/charts/hoppscotch/templates/aio/deployment.yaml
+++ b/charts/hoppscotch/templates/aio/deployment.yaml
@@ -44,15 +44,15 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "hoppscotch.serviceAccountName" . }}
-      {{- with .Values.aio.podSecurityContext }}
+      {{- with (include "hoppscotch.compatibility.renderSecurityContext" (dict "secContext" .Values.aio.podSecurityContext "context" $)) }}
       securityContext:
-        {{- toYaml . | nindent 8 }}
+        {{- . | nindent 8 }}
       {{- end }}
       containers:
         - name: hoppscotch
-          {{- with .Values.aio.securityContext }}
+          {{- with (include "hoppscotch.compatibility.renderSecurityContext" (dict "secContext" .Values.aio.securityContext "context" $)) }}
           securityContext:
-            {{- toYaml . | nindent 12 }}
+            {{- . | nindent 12 }}
           {{- end }}
           image: {{ include "hoppscotch.image" (dict "component" .Values.aio "context" .) }}
           imagePullPolicy: {{ .Values.aio.image.pullPolicy }}

--- a/charts/hoppscotch/templates/aio/route.yaml
+++ b/charts/hoppscotch/templates/aio/route.yaml
@@ -1,0 +1,38 @@
+{{- if and (eq .Values.deploymentMode "aio") .Values.aio.route.enabled }}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ include "hoppscotch.aio.serviceName" . }}
+  namespace: {{ include "hoppscotch.namespace" . | quote }}
+  labels:
+    app.kubernetes.io/component: hoppscotch
+    {{- include "hoppscotch.labels" . | nindent 4 }}
+  {{- if or .Values.commonAnnotations .Values.aio.route.annotations }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- toYaml .Values.commonAnnotations | nindent 4 }}
+    {{- end }}
+    {{- if .Values.aio.route.annotations }}
+    {{- toYaml .Values.aio.route.annotations | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  {{- if .Values.aio.route.host }}
+  host: {{ .Values.aio.route.host | quote }}
+  {{- end }}
+  {{- if .Values.aio.route.path }}
+  path: {{ .Values.aio.route.path | quote }}
+  {{- end }}
+  to:
+    kind: Service
+    name: {{ include "hoppscotch.aio.serviceName" . }}
+    weight: 100
+  port:
+    targetPort: {{ .Values.aio.route.targetPort }}
+  {{- if .Values.aio.route.tls.enabled }}
+  tls:
+    termination: {{ .Values.aio.route.tls.termination }}
+    insecureEdgeTerminationPolicy: {{ .Values.aio.route.tls.insecureEdgeTerminationPolicy }}
+  {{- end }}
+  wildcardPolicy: {{ .Values.aio.route.wildcardPolicy }}
+{{- end }}

--- a/charts/hoppscotch/templates/aio/route.yaml
+++ b/charts/hoppscotch/templates/aio/route.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq .Values.deploymentMode "aio") .Values.aio.route.enabled }}
+{{- if and (eq .Values.deploymentMode "aio") .Values.aio.route.enabled (.Capabilities.APIVersions.Has "route.openshift.io/v1") }}
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:

--- a/charts/hoppscotch/templates/backend/deployment.yaml
+++ b/charts/hoppscotch/templates/backend/deployment.yaml
@@ -44,15 +44,15 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "hoppscotch.serviceAccountName" . }}
-      {{- with .Values.backend.podSecurityContext }}
+      {{- with (include "hoppscotch.compatibility.renderSecurityContext" (dict "secContext" .Values.backend.podSecurityContext "context" $)) }}
       securityContext:
-        {{- toYaml . | nindent 8 }}
+        {{- . | nindent 8 }}
       {{- end }}
       containers:
         - name: hoppscotch
-          {{- with .Values.backend.securityContext }}
+          {{- with (include "hoppscotch.compatibility.renderSecurityContext" (dict "secContext" .Values.backend.securityContext "context" $)) }}
           securityContext:
-            {{- toYaml . | nindent 12 }}
+            {{- . | nindent 12 }}
           {{- end }}
           image: {{ include "hoppscotch.image" (dict "component" .Values.backend "context" .) }}
           imagePullPolicy: {{ .Values.backend.image.pullPolicy }}

--- a/charts/hoppscotch/templates/backend/route.yaml
+++ b/charts/hoppscotch/templates/backend/route.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq .Values.deploymentMode "distributed") .Values.backend.route.enabled }}
+{{- if and (eq .Values.deploymentMode "distributed") .Values.backend.route.enabled (.Capabilities.APIVersions.Has "route.openshift.io/v1") }}
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:

--- a/charts/hoppscotch/templates/backend/route.yaml
+++ b/charts/hoppscotch/templates/backend/route.yaml
@@ -1,0 +1,38 @@
+{{- if and (eq .Values.deploymentMode "distributed") .Values.backend.route.enabled }}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ include "hoppscotch.backend.serviceName" . }}
+  namespace: {{ include "hoppscotch.namespace" . | quote }}
+  labels:
+    app.kubernetes.io/component: hoppscotch-backend
+    {{- include "hoppscotch.labels" . | nindent 4 }}
+  {{- if or .Values.commonAnnotations .Values.backend.route.annotations }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- toYaml .Values.commonAnnotations | nindent 4 }}
+    {{- end }}
+    {{- if .Values.backend.route.annotations }}
+    {{- toYaml .Values.backend.route.annotations | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  {{- if .Values.backend.route.host }}
+  host: {{ .Values.backend.route.host | quote }}
+  {{- end }}
+  {{- if .Values.backend.route.path }}
+  path: {{ .Values.backend.route.path | quote }}
+  {{- end }}
+  to:
+    kind: Service
+    name: {{ include "hoppscotch.backend.serviceName" . }}
+    weight: 100
+  port:
+    targetPort: {{ .Values.backend.route.targetPort }}
+  {{- if .Values.backend.route.tls.enabled }}
+  tls:
+    termination: {{ .Values.backend.route.tls.termination }}
+    insecureEdgeTerminationPolicy: {{ .Values.backend.route.tls.insecureEdgeTerminationPolicy }}
+  {{- end }}
+  wildcardPolicy: {{ .Values.backend.route.wildcardPolicy }}
+{{- end }}

--- a/charts/hoppscotch/templates/frontend/deployment.yaml
+++ b/charts/hoppscotch/templates/frontend/deployment.yaml
@@ -44,15 +44,15 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "hoppscotch.serviceAccountName" . }}
-      {{- with .Values.frontend.podSecurityContext }}
+      {{- with (include "hoppscotch.compatibility.renderSecurityContext" (dict "secContext" .Values.frontend.podSecurityContext "context" $)) }}
       securityContext:
-        {{- toYaml . | nindent 8 }}
+        {{- . | nindent 8 }}
       {{- end }}
       containers:
         - name: hoppscotch
-          {{- with .Values.frontend.securityContext }}
+          {{- with (include "hoppscotch.compatibility.renderSecurityContext" (dict "secContext" .Values.frontend.securityContext "context" $)) }}
           securityContext:
-            {{- toYaml . | nindent 12 }}
+            {{- . | nindent 12 }}
           {{- end }}
           image: {{ include "hoppscotch.image" (dict "component" .Values.frontend "context" .) }}
           imagePullPolicy: {{ .Values.frontend.image.pullPolicy }}

--- a/charts/hoppscotch/templates/frontend/route.yaml
+++ b/charts/hoppscotch/templates/frontend/route.yaml
@@ -1,0 +1,38 @@
+{{- if and (eq .Values.deploymentMode "distributed") .Values.frontend.route.enabled }}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ include "hoppscotch.frontend.serviceName" . }}
+  namespace: {{ include "hoppscotch.namespace" . | quote }}
+  labels:
+    app.kubernetes.io/component: hoppscotch-frontend
+    {{- include "hoppscotch.labels" . | nindent 4 }}
+  {{- if or .Values.commonAnnotations .Values.frontend.route.annotations }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- toYaml .Values.commonAnnotations | nindent 4 }}
+    {{- end }}
+    {{- if .Values.frontend.route.annotations }}
+    {{- toYaml .Values.frontend.route.annotations | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  {{- if .Values.frontend.route.host }}
+  host: {{ .Values.frontend.route.host | quote }}
+  {{- end }}
+  {{- if .Values.frontend.route.path }}
+  path: {{ .Values.frontend.route.path | quote }}
+  {{- end }}
+  to:
+    kind: Service
+    name: {{ include "hoppscotch.frontend.serviceName" . }}
+    weight: 100
+  port:
+    targetPort: {{ .Values.frontend.route.targetPort }}
+  {{- if .Values.frontend.route.tls.enabled }}
+  tls:
+    termination: {{ .Values.frontend.route.tls.termination }}
+    insecureEdgeTerminationPolicy: {{ .Values.frontend.route.tls.insecureEdgeTerminationPolicy }}
+  {{- end }}
+  wildcardPolicy: {{ .Values.frontend.route.wildcardPolicy }}
+{{- end }}

--- a/charts/hoppscotch/templates/frontend/route.yaml
+++ b/charts/hoppscotch/templates/frontend/route.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq .Values.deploymentMode "distributed") .Values.frontend.route.enabled }}
+{{- if and (eq .Values.deploymentMode "distributed") .Values.frontend.route.enabled (.Capabilities.APIVersions.Has "route.openshift.io/v1") }}
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:

--- a/charts/hoppscotch/tests/aio_route_test.yaml
+++ b/charts/hoppscotch/tests/aio_route_test.yaml
@@ -6,6 +6,9 @@ templates:
 tests:
   - it: should generate Route when deployment mode is aio and route is enabled
     template: aio/route.yaml
+    capabilities:
+      apiVersions:
+        - route.openshift.io/v1
     set:
       deploymentMode: aio
       aio:
@@ -50,8 +53,24 @@ tests:
       - hasDocuments:
           count: 0
 
+  - it: should not generate Route when the Route API is unavailable
+    template: aio/route.yaml
+    capabilities:
+      apiVersions: []
+    set:
+      deploymentMode: aio
+      aio:
+        route:
+          enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
   - it: should set host, path and disable TLS when configured
     template: aio/route.yaml
+    capabilities:
+      apiVersions:
+        - route.openshift.io/v1
     set:
       deploymentMode: aio
       aio:

--- a/charts/hoppscotch/tests/aio_route_test.yaml
+++ b/charts/hoppscotch/tests/aio_route_test.yaml
@@ -1,0 +1,76 @@
+suite: AIO Route
+templates:
+  - aio/route.yaml
+  - config/configmap.yaml
+  - config/secret.yaml
+tests:
+  - it: should generate Route when deployment mode is aio and route is enabled
+    template: aio/route.yaml
+    set:
+      deploymentMode: aio
+      aio:
+        route:
+          enabled: true
+    asserts:
+      - containsDocument:
+          apiVersion: route.openshift.io/v1
+          kind: Route
+      - equal:
+          path: metadata.name
+          value: release-name-hoppscotch
+      - equal:
+          path: spec.to.name
+          value: release-name-hoppscotch
+      - equal:
+          path: spec.port.targetPort
+          value: http
+      - equal:
+          path: spec.tls.termination
+          value: edge
+
+  - it: should not generate Route when route is disabled
+    template: aio/route.yaml
+    set:
+      deploymentMode: aio
+      aio:
+        route:
+          enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not generate Route when deployment mode is not aio
+    template: aio/route.yaml
+    set:
+      deploymentMode: distributed
+      aio:
+        route:
+          enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should set host, path and disable TLS when configured
+    template: aio/route.yaml
+    set:
+      deploymentMode: aio
+      aio:
+        route:
+          enabled: true
+          host: hoppscotch.apps.example.com
+          path: /
+          targetPort: http-frontend
+          tls:
+            enabled: false
+    asserts:
+      - equal:
+          path: spec.host
+          value: hoppscotch.apps.example.com
+      - equal:
+          path: spec.path
+          value: /
+      - equal:
+          path: spec.port.targetPort
+          value: http-frontend
+      - notExists:
+          path: spec.tls

--- a/charts/hoppscotch/tests/distributed_route_test.yaml
+++ b/charts/hoppscotch/tests/distributed_route_test.yaml
@@ -1,0 +1,75 @@
+suite: Distributed Routes
+templates:
+  - frontend/route.yaml
+  - backend/route.yaml
+  - admin/route.yaml
+  - config/configmap.yaml
+  - config/secret.yaml
+tests:
+  - it: should generate frontend Route in distributed mode when enabled
+    template: frontend/route.yaml
+    set:
+      deploymentMode: distributed
+      frontend:
+        route:
+          enabled: true
+    asserts:
+      - containsDocument:
+          apiVersion: route.openshift.io/v1
+          kind: Route
+      - equal:
+          path: metadata.name
+          value: release-name-hoppscotch-frontend
+      - equal:
+          path: spec.to.name
+          value: release-name-hoppscotch-frontend
+
+  - it: should generate backend Route in distributed mode when enabled
+    template: backend/route.yaml
+    set:
+      deploymentMode: distributed
+      backend:
+        route:
+          enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: release-name-hoppscotch-backend
+      - equal:
+          path: spec.to.name
+          value: release-name-hoppscotch-backend
+
+  - it: should generate admin Route in distributed mode when enabled
+    template: admin/route.yaml
+    set:
+      deploymentMode: distributed
+      admin:
+        route:
+          enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: release-name-hoppscotch-admin
+      - equal:
+          path: spec.to.name
+          value: release-name-hoppscotch-admin
+
+  - it: should not generate distributed Routes in aio mode
+    templates:
+      - frontend/route.yaml
+      - backend/route.yaml
+      - admin/route.yaml
+    set:
+      deploymentMode: aio
+      frontend:
+        route:
+          enabled: true
+      backend:
+        route:
+          enabled: true
+      admin:
+        route:
+          enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/hoppscotch/tests/distributed_route_test.yaml
+++ b/charts/hoppscotch/tests/distributed_route_test.yaml
@@ -8,6 +8,9 @@ templates:
 tests:
   - it: should generate frontend Route in distributed mode when enabled
     template: frontend/route.yaml
+    capabilities:
+      apiVersions:
+        - route.openshift.io/v1
     set:
       deploymentMode: distributed
       frontend:
@@ -26,6 +29,9 @@ tests:
 
   - it: should generate backend Route in distributed mode when enabled
     template: backend/route.yaml
+    capabilities:
+      apiVersions:
+        - route.openshift.io/v1
     set:
       deploymentMode: distributed
       backend:
@@ -41,6 +47,9 @@ tests:
 
   - it: should generate admin Route in distributed mode when enabled
     template: admin/route.yaml
+    capabilities:
+      apiVersions:
+        - route.openshift.io/v1
     set:
       deploymentMode: distributed
       admin:
@@ -61,6 +70,28 @@ tests:
       - admin/route.yaml
     set:
       deploymentMode: aio
+      frontend:
+        route:
+          enabled: true
+      backend:
+        route:
+          enabled: true
+      admin:
+        route:
+          enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not generate distributed Routes when the Route API is unavailable
+    templates:
+      - frontend/route.yaml
+      - backend/route.yaml
+      - admin/route.yaml
+    capabilities:
+      apiVersions: []
+    set:
+      deploymentMode: distributed
       frontend:
         route:
           enabled: true

--- a/charts/hoppscotch/tests/distributed_route_test.yaml
+++ b/charts/hoppscotch/tests/distributed_route_test.yaml
@@ -38,6 +38,9 @@ tests:
         route:
           enabled: true
     asserts:
+      - containsDocument:
+          apiVersion: route.openshift.io/v1
+          kind: Route
       - equal:
           path: metadata.name
           value: release-name-hoppscotch-backend
@@ -56,6 +59,9 @@ tests:
         route:
           enabled: true
     asserts:
+      - containsDocument:
+          apiVersion: route.openshift.io/v1
+          kind: Route
       - equal:
           path: metadata.name
           value: release-name-hoppscotch-admin

--- a/charts/hoppscotch/tests/openshift_security_context_test.yaml
+++ b/charts/hoppscotch/tests/openshift_security_context_test.yaml
@@ -1,0 +1,140 @@
+suite: OpenShift Security Context Adaptation
+templates:
+  - aio/deployment.yaml
+  - config/configmap.yaml
+  - config/secret.yaml
+tests:
+  - it: should keep runAsUser, runAsGroup and fsGroup on plain Kubernetes by default
+    template: aio/deployment.yaml
+    set:
+      deploymentMode: aio
+      aio:
+        podSecurityContext:
+          fsGroup: 1000
+          runAsUser: 1000
+          runAsGroup: 1000
+          runAsNonRoot: true
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 1000
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 1000
+      - equal:
+          path: spec.template.spec.securityContext.runAsGroup
+          value: 1000
+      - equal:
+          path: spec.template.spec.securityContext.runAsNonRoot
+          value: true
+
+  - it: should not render a securityContext when none is configured
+    template: aio/deployment.yaml
+    set:
+      deploymentMode: aio
+    asserts:
+      - notExists:
+          path: spec.template.spec.securityContext
+      - notExists:
+          path: spec.template.spec.containers[0].securityContext
+
+  - it: should strip runAsUser, runAsGroup and fsGroup when adaptSecurityContext is force
+    template: aio/deployment.yaml
+    set:
+      deploymentMode: aio
+      global:
+        compatibility:
+          openshift:
+            adaptSecurityContext: force
+      aio:
+        podSecurityContext:
+          fsGroup: 1000
+          runAsUser: 1000
+          runAsGroup: 1000
+          runAsNonRoot: true
+        securityContext:
+          runAsUser: 1000
+          allowPrivilegeEscalation: false
+    asserts:
+      - notExists:
+          path: spec.template.spec.securityContext.fsGroup
+      - notExists:
+          path: spec.template.spec.securityContext.runAsUser
+      - notExists:
+          path: spec.template.spec.securityContext.runAsGroup
+      - equal:
+          path: spec.template.spec.securityContext.runAsNonRoot
+          value: true
+      - notExists:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+
+  - it: should not adapt when adaptSecurityContext is disabled even on OpenShift
+    template: aio/deployment.yaml
+    capabilities:
+      apiVersions:
+        - security.openshift.io/v1/SecurityContextConstraints
+    set:
+      deploymentMode: aio
+      global:
+        compatibility:
+          openshift:
+            adaptSecurityContext: disabled
+      aio:
+        podSecurityContext:
+          runAsUser: 1000
+          fsGroup: 1000
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 1000
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 1000
+
+  - it: should adapt automatically when an OpenShift cluster is detected
+    template: aio/deployment.yaml
+    capabilities:
+      apiVersions:
+        - security.openshift.io/v1/SecurityContextConstraints
+    set:
+      deploymentMode: aio
+      global:
+        compatibility:
+          openshift:
+            adaptSecurityContext: auto
+      aio:
+        podSecurityContext:
+          runAsUser: 1000
+          fsGroup: 1000
+          runAsNonRoot: true
+    asserts:
+      - notExists:
+          path: spec.template.spec.securityContext.runAsUser
+      - notExists:
+          path: spec.template.spec.securityContext.fsGroup
+      - equal:
+          path: spec.template.spec.securityContext.runAsNonRoot
+          value: true
+
+  - it: should not adapt on auto when no OpenShift cluster is detected
+    template: aio/deployment.yaml
+    set:
+      deploymentMode: aio
+      global:
+        compatibility:
+          openshift:
+            adaptSecurityContext: auto
+      aio:
+        podSecurityContext:
+          runAsUser: 1000
+          fsGroup: 1000
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 1000
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 1000

--- a/charts/hoppscotch/tests/openshift_security_context_test.yaml
+++ b/charts/hoppscotch/tests/openshift_security_context_test.yaml
@@ -1,6 +1,9 @@
 suite: OpenShift Security Context Adaptation
 templates:
   - aio/deployment.yaml
+  - frontend/deployment.yaml
+  - backend/deployment.yaml
+  - admin/deployment.yaml
   - config/configmap.yaml
   - config/secret.yaml
 tests:
@@ -137,4 +140,139 @@ tests:
           value: 1000
       - equal:
           path: spec.template.spec.securityContext.fsGroup
+          value: 1000
+
+  - it: should strip runAsUser, runAsGroup and fsGroup on the frontend deployment when force
+    template: frontend/deployment.yaml
+    set:
+      deploymentMode: distributed
+      global:
+        compatibility:
+          openshift:
+            adaptSecurityContext: force
+      frontend:
+        podSecurityContext:
+          fsGroup: 1000
+          runAsUser: 1000
+          runAsGroup: 1000
+          runAsNonRoot: true
+    asserts:
+      - notExists:
+          path: spec.template.spec.securityContext.fsGroup
+      - notExists:
+          path: spec.template.spec.securityContext.runAsUser
+      - notExists:
+          path: spec.template.spec.securityContext.runAsGroup
+      - equal:
+          path: spec.template.spec.securityContext.runAsNonRoot
+          value: true
+
+  - it: should keep runAsUser, runAsGroup and fsGroup on the frontend deployment on plain Kubernetes
+    template: frontend/deployment.yaml
+    set:
+      deploymentMode: distributed
+      frontend:
+        podSecurityContext:
+          fsGroup: 1000
+          runAsUser: 1000
+          runAsGroup: 1000
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 1000
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 1000
+      - equal:
+          path: spec.template.spec.securityContext.runAsGroup
+          value: 1000
+
+  - it: should strip runAsUser, runAsGroup and fsGroup on the backend deployment when force
+    template: backend/deployment.yaml
+    set:
+      deploymentMode: distributed
+      global:
+        compatibility:
+          openshift:
+            adaptSecurityContext: force
+      backend:
+        podSecurityContext:
+          fsGroup: 1000
+          runAsUser: 1000
+          runAsGroup: 1000
+          runAsNonRoot: true
+    asserts:
+      - notExists:
+          path: spec.template.spec.securityContext.fsGroup
+      - notExists:
+          path: spec.template.spec.securityContext.runAsUser
+      - notExists:
+          path: spec.template.spec.securityContext.runAsGroup
+      - equal:
+          path: spec.template.spec.securityContext.runAsNonRoot
+          value: true
+
+  - it: should keep runAsUser, runAsGroup and fsGroup on the backend deployment on plain Kubernetes
+    template: backend/deployment.yaml
+    set:
+      deploymentMode: distributed
+      backend:
+        podSecurityContext:
+          fsGroup: 1000
+          runAsUser: 1000
+          runAsGroup: 1000
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 1000
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 1000
+      - equal:
+          path: spec.template.spec.securityContext.runAsGroup
+          value: 1000
+
+  - it: should strip runAsUser, runAsGroup and fsGroup on the admin deployment when force
+    template: admin/deployment.yaml
+    set:
+      deploymentMode: distributed
+      global:
+        compatibility:
+          openshift:
+            adaptSecurityContext: force
+      admin:
+        podSecurityContext:
+          fsGroup: 1000
+          runAsUser: 1000
+          runAsGroup: 1000
+          runAsNonRoot: true
+    asserts:
+      - notExists:
+          path: spec.template.spec.securityContext.fsGroup
+      - notExists:
+          path: spec.template.spec.securityContext.runAsUser
+      - notExists:
+          path: spec.template.spec.securityContext.runAsGroup
+      - equal:
+          path: spec.template.spec.securityContext.runAsNonRoot
+          value: true
+
+  - it: should keep runAsUser, runAsGroup and fsGroup on the admin deployment on plain Kubernetes
+    template: admin/deployment.yaml
+    set:
+      deploymentMode: distributed
+      admin:
+        podSecurityContext:
+          fsGroup: 1000
+          runAsUser: 1000
+          runAsGroup: 1000
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 1000
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 1000
+      - equal:
+          path: spec.template.spec.securityContext.runAsGroup
           value: 1000

--- a/charts/hoppscotch/values.yaml
+++ b/charts/hoppscotch/values.yaml
@@ -14,6 +14,11 @@ global:
     # -- Allows skipping image verification
     # @section -- Global Parameters
     allowInsecureImages: false
+  compatibility:
+    openshift:
+      # -- Adapt the securityContext sections of Hoppscotch and its dependencies to be compatible with OpenShift restricted-v2 SCC: removes `runAsUser`, `runAsGroup` and `fsGroup` so the platform assigns IDs from the namespace's allowed range. Possible values: `auto` (apply only if an OpenShift cluster is detected), `force` (always apply), `disabled` (never apply)
+      # @section -- Global Parameters
+      adaptSecurityContext: auto
 
 # @section -- Common Parameters
 
@@ -613,6 +618,36 @@ aio:
     # @section -- Hoppscotch AIO Container Parameters
     extraRules: []
 
+  route:
+    # -- Enable OpenShift Route for Hoppscotch (OpenShift only, alternative to ingress)
+    # @section -- Hoppscotch AIO Container Parameters
+    enabled: false
+    # -- Route hostname (auto-assigned by OpenShift when left empty)
+    # @section -- Hoppscotch AIO Container Parameters
+    host: ""
+    # -- Route path
+    # @section -- Hoppscotch AIO Container Parameters
+    path: ""
+    # -- Service target port name or number the Route forwards to
+    # @section -- Hoppscotch AIO Container Parameters
+    targetPort: http
+    # -- Route wildcard policy (None or Subdomain)
+    # @section -- Hoppscotch AIO Container Parameters
+    wildcardPolicy: None
+    # -- Route annotations
+    # @section -- Hoppscotch AIO Container Parameters
+    annotations: {}
+    tls:
+      # -- Enable TLS for the Route
+      # @section -- Hoppscotch AIO Container Parameters
+      enabled: true
+      # -- TLS termination type (edge, passthrough or reencrypt)
+      # @section -- Hoppscotch AIO Container Parameters
+      termination: edge
+      # -- Insecure traffic policy (None, Allow or Redirect)
+      # @section -- Hoppscotch AIO Container Parameters
+      insecureEdgeTerminationPolicy: Redirect
+
   persistence:
     # -- Enable persistent storage for Hoppscotch
     # @section -- Hoppscotch AIO Container Parameters
@@ -949,6 +984,36 @@ frontend:
     # -- Extra ingress rules
     # @section -- Hoppscotch Frontend Container Parameters
     extraRules: []
+
+  route:
+    # -- Enable OpenShift Route for Hoppscotch (OpenShift only, alternative to ingress)
+    # @section -- Hoppscotch Frontend Container Parameters
+    enabled: false
+    # -- Route hostname (auto-assigned by OpenShift when left empty)
+    # @section -- Hoppscotch Frontend Container Parameters
+    host: ""
+    # -- Route path
+    # @section -- Hoppscotch Frontend Container Parameters
+    path: ""
+    # -- Service target port name or number the Route forwards to
+    # @section -- Hoppscotch Frontend Container Parameters
+    targetPort: http
+    # -- Route wildcard policy (None or Subdomain)
+    # @section -- Hoppscotch Frontend Container Parameters
+    wildcardPolicy: None
+    # -- Route annotations
+    # @section -- Hoppscotch Frontend Container Parameters
+    annotations: {}
+    tls:
+      # -- Enable TLS for the Route
+      # @section -- Hoppscotch Frontend Container Parameters
+      enabled: true
+      # -- TLS termination type (edge, passthrough or reencrypt)
+      # @section -- Hoppscotch Frontend Container Parameters
+      termination: edge
+      # -- Insecure traffic policy (None, Allow or Redirect)
+      # @section -- Hoppscotch Frontend Container Parameters
+      insecureEdgeTerminationPolicy: Redirect
 
   persistence:
     # -- Enable persistent storage for Hoppscotch
@@ -1287,6 +1352,36 @@ backend:
     # @section -- Hoppscotch Backend Container Parameters
     extraRules: []
 
+  route:
+    # -- Enable OpenShift Route for Hoppscotch (OpenShift only, alternative to ingress)
+    # @section -- Hoppscotch Backend Container Parameters
+    enabled: false
+    # -- Route hostname (auto-assigned by OpenShift when left empty)
+    # @section -- Hoppscotch Backend Container Parameters
+    host: ""
+    # -- Route path
+    # @section -- Hoppscotch Backend Container Parameters
+    path: ""
+    # -- Service target port name or number the Route forwards to
+    # @section -- Hoppscotch Backend Container Parameters
+    targetPort: http
+    # -- Route wildcard policy (None or Subdomain)
+    # @section -- Hoppscotch Backend Container Parameters
+    wildcardPolicy: None
+    # -- Route annotations
+    # @section -- Hoppscotch Backend Container Parameters
+    annotations: {}
+    tls:
+      # -- Enable TLS for the Route
+      # @section -- Hoppscotch Backend Container Parameters
+      enabled: true
+      # -- TLS termination type (edge, passthrough or reencrypt)
+      # @section -- Hoppscotch Backend Container Parameters
+      termination: edge
+      # -- Insecure traffic policy (None, Allow or Redirect)
+      # @section -- Hoppscotch Backend Container Parameters
+      insecureEdgeTerminationPolicy: Redirect
+
   persistence:
     # -- Enable persistent storage for Hoppscotch
     # @section -- Hoppscotch Backend Container Parameters
@@ -1623,6 +1718,36 @@ admin:
     # -- Extra ingress rules
     # @section -- Hoppscotch Admin Container Parameters
     extraRules: []
+
+  route:
+    # -- Enable OpenShift Route for Hoppscotch (OpenShift only, alternative to ingress)
+    # @section -- Hoppscotch Admin Container Parameters
+    enabled: false
+    # -- Route hostname (auto-assigned by OpenShift when left empty)
+    # @section -- Hoppscotch Admin Container Parameters
+    host: ""
+    # -- Route path
+    # @section -- Hoppscotch Admin Container Parameters
+    path: ""
+    # -- Service target port name or number the Route forwards to
+    # @section -- Hoppscotch Admin Container Parameters
+    targetPort: http
+    # -- Route wildcard policy (None or Subdomain)
+    # @section -- Hoppscotch Admin Container Parameters
+    wildcardPolicy: None
+    # -- Route annotations
+    # @section -- Hoppscotch Admin Container Parameters
+    annotations: {}
+    tls:
+      # -- Enable TLS for the Route
+      # @section -- Hoppscotch Admin Container Parameters
+      enabled: true
+      # -- TLS termination type (edge, passthrough or reencrypt)
+      # @section -- Hoppscotch Admin Container Parameters
+      termination: edge
+      # -- Insecure traffic policy (None, Allow or Redirect)
+      # @section -- Hoppscotch Admin Container Parameters
+      insecureEdgeTerminationPolicy: Redirect
 
   persistence:
     # -- Enable persistent storage for Hoppscotch


### PR DESCRIPTION
## Summary

Lets the chart run on OpenShift as well as plain Kubernetes from the same values file.

- Adds `global.compatibility.openshift.adaptSecurityContext` (`auto`/`force`/`disabled`).
  When active it drops `runAsUser`, `runAsGroup` and `fsGroup` so pods are accepted by the
  `restricted-v2` SCC. The flag is also inherited by the PostgreSQL, Redis and ClickHouse
  dependencies. It defaults to `auto`, which only kicks in on an actual OpenShift cluster,
  so nothing changes on vanilla Kubernetes.
- Adds optional OpenShift `Route` resources for the aio/frontend/backend/admin components
  as an alternative to Ingress, off by default (`<component>.route.enabled`).
- Updates the README with an OpenShift section and adds unit tests for both.

## Test plan

- [x] `helm lint` (default and with the databases enabled)
- [x] `helm template` for AIO and distributed modes
- [x] `adaptSecurityContext=force` strips the IDs from the workloads and the dependencies
- [x] `helm unittest` passes for the new security context and Route suites
